### PR TITLE
refactor: move auth to client module

### DIFF
--- a/docs/gitcode/index.md
+++ b/docs/gitcode/index.md
@@ -19,8 +19,10 @@ title: gitcode 工具库
   - `listPullRequests(owner, repo, query?)`：获取仓库的 Pull Request 列表。
   - `createPullRequest(owner, repo, body)`：创建 Pull Request（支持字段：`title`、`head`、`base`、`body`、`issue`）。
   - 也可通过模块方式调用：`client.repo.getSelfRepoPermissionRole()`、`client.pr.list()`、`client.pr.create()` 等。
-- `GitcodeAuth`
-  - 本地令牌存储与加载，提供 `setToken/token/status/client`。
+- `GitcodeClientAuth`
+  - 通过 `client.auth` 提供本地令牌存储与加载。
+- `createGitcodeClient()`
+  - 读取 token 并返回 `GitcodeClient` 实例。
 - `FileAuthStorage`、`defaultConfigPath()`
 
 更多 API：
@@ -54,18 +56,17 @@ title: gitcode 工具库
 1. 环境变量 `GITCODE_TOKEN`
 2. 本地配置文件 `~/.gitany/gitcode/config.json`
 
-### GitcodeAuth 用法
+### 认证使用示例
 
 ```ts
-import { GitcodeAuth } from '@gitany/gitcode';
+import { createGitcodeClient } from '@gitany/gitcode';
 
-const auth = new GitcodeAuth();
-await auth.setToken('your_token', 'bearer');
+const client = await createGitcodeClient();
+await client.auth.setToken('your_token', 'bearer');
 
-const token = await auth.token(); // 获取token（环境变量优先）
+const token = await client.auth.token(); // 获取 token（环境变量优先）
 console.log(token);
 
-const client = await auth.client();
 const me = await client.request('/user', 'GET');
 ```
 

--- a/docs/gitcode/user.md
+++ b/docs/gitcode/user.md
@@ -87,11 +87,9 @@ try {
 ### 结合认证使用
 
 ```typescript
-import { GitcodeAuth } from '@gitany/gitcode';
+import { createGitcodeClient } from '@gitany/gitcode';
 
-const auth = new GitcodeAuth();
-const client = await auth.client();
-
+const client = await createGitcodeClient();
 const profile = await client.getUserProfile();
 console.log('当前用户:', profile.name);
 ```

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,25 +1,22 @@
 import { Command } from 'commander';
-import { GitcodeAuth } from '@gitany/gitcode';
+import { createGitcodeClient } from '@gitany/gitcode';
 
 export function authCommand(): Command {
-  const auth = new GitcodeAuth();
-  
-  const authProgram = new Command('auth')
-    .description('Authentication commands');
+  const authProgram = new Command('auth').description('Authentication commands');
 
   authProgram
     .command('set-token')
     .description('Set authentication token')
     .argument('<token>', 'Authentication token')
-    .action((token) => {
-      auth.setToken(token.trim())
-        .then(() => {
-          console.log('Token saved successfully');
-        })
-        .catch((error) => {
-          console.error('Failed to save token:', error);
-          process.exit(1);
-        });
+    .action(async (token) => {
+      try {
+        const client = await createGitcodeClient();
+        await client.auth.setToken(token.trim());
+        console.log('Token saved successfully');
+      } catch (error) {
+        console.error('Failed to save token:', error);
+        process.exit(1);
+      }
     });
 
   return authProgram;

--- a/packages/cli/src/commands/pr/create.ts
+++ b/packages/cli/src/commands/pr/create.ts
@@ -1,8 +1,9 @@
-import { GitcodeAuth, parseGitUrl } from '@gitany/gitcode';
+import { createGitcodeClient, parseGitUrl, type CreatePullBody } from '@gitany/gitcode';
 
-export async function createCommand(url: string, options: any): Promise<void> {
-  const auth = new GitcodeAuth();
-  
+export async function createCommand(
+  url: string,
+  options: Record<string, string | undefined>,
+): Promise<void> {
   try {
     const remote = parseGitUrl(url);
     if (!remote) {
@@ -11,7 +12,7 @@ export async function createCommand(url: string, options: any): Promise<void> {
       return;
     }
 
-    const body: any = {
+    const body: CreatePullBody = {
       title: options.title,
       head: options.head,
     };
@@ -28,7 +29,7 @@ export async function createCommand(url: string, options: any): Promise<void> {
       body.issue = n;
     }
 
-    const client = await auth.client();
+    const client = await createGitcodeClient();
     const created = await client.pr.create(remote.owner, remote.repo, body);
 
     if (options.json) {
@@ -36,9 +37,9 @@ export async function createCommand(url: string, options: any): Promise<void> {
       return;
     }
 
-    const pr: any = created;
-    const num = (pr?.number ?? pr?.iid ?? pr?.id) as number | string | undefined;
-    const titleOut = (pr?.title ?? '(no title)') as string;
+    const pr = created as Record<string, unknown>;
+    const num = (pr.number ?? pr.iid ?? pr.id) as number | string | undefined;
+    const titleOut = (pr.title ?? '(no title)') as string;
     const numStr = typeof num === 'number' ? num : (num ?? '?');
     console.log(`Created PR #${numStr}: ${titleOut}`);
   } catch (err) {

--- a/packages/cli/src/commands/pr/list.ts
+++ b/packages/cli/src/commands/pr/list.ts
@@ -1,8 +1,9 @@
-import { GitcodeAuth, parseGitUrl } from '@gitany/gitcode';
+import { createGitcodeClient, parseGitUrl } from '@gitany/gitcode';
 
-export async function listCommand(url: string, options: any): Promise<void> {
-  const auth = new GitcodeAuth();
-  
+export async function listCommand(
+  url: string,
+  options: Record<string, string | undefined>,
+): Promise<void> {
   try {
     const remote = parseGitUrl(url);
     if (!remote) {
@@ -11,7 +12,7 @@ export async function listCommand(url: string, options: any): Promise<void> {
       return;
     }
 
-    const client = await auth.client();
+    const client = await createGitcodeClient();
     const pulls = await client.pr.list(remote.owner, remote.repo, {
       state: options.state,
       head: options.head,
@@ -26,9 +27,10 @@ export async function listCommand(url: string, options: any): Promise<void> {
     }
 
     // Default: print bullet list of titles: - [#<number>] <title>
-    for (const pr of pulls as any[]) {
-      const num = (pr?.number ?? pr?.iid ?? pr?.id) as number | string | undefined;
-      const title = (pr?.title ?? pr?.subject ?? pr?.name ?? '(no title)') as string;
+    for (const pr of pulls as unknown[]) {
+      const item = pr as Record<string, unknown>;
+      const num = (item.number ?? item.iid ?? item.id) as number | string | undefined;
+      const title = (item.title ?? item.subject ?? item.name ?? '(no title)') as string;
       const numStr = typeof num === 'number' ? num : (num ?? '?');
       console.log(`- [#${numStr}] ${title}`);
     }

--- a/packages/cli/src/commands/repo/permission.ts
+++ b/packages/cli/src/commands/repo/permission.ts
@@ -1,4 +1,4 @@
-import { GitcodeAuth, parseGitUrl } from '@gitany/gitcode';
+import { createGitcodeClient, parseGitUrl } from '@gitany/gitcode';
 
 export async function permissionCommand(url: string): Promise<void> {
   try {
@@ -11,8 +11,7 @@ export async function permissionCommand(url: string): Promise<void> {
 
     const { owner, repo } = remote;
 
-    const auth = new GitcodeAuth();
-    const client = await auth.client();
+    const client = await createGitcodeClient();
     const permission = await client.repo.getSelfRepoPermissionRole(owner, repo);
     console.log(permission);
   } catch (err) {

--- a/packages/cli/src/commands/user/index.ts
+++ b/packages/cli/src/commands/user/index.ts
@@ -1,10 +1,9 @@
 import { Command } from 'commander';
-import { GitcodeAuth } from '@gitany/gitcode';
+import { createGitcodeClient } from '@gitany/gitcode';
 
 export async function userShowCommand(): Promise<void> {
   try {
-    const auth = new GitcodeAuth();
-    const client = await auth.client();
+    const client = await createGitcodeClient();
     const user = await client.user.getProfile();
 
     console.log('用户信息:');

--- a/packages/git-lib/src/index.ts
+++ b/packages/git-lib/src/index.ts
@@ -37,11 +37,12 @@ async function runGit(args: string[], opts: GitExecOptions = {}): Promise<GitRes
       stderr += d.toString();
     });
 
-    child.on('error', (err: any) => {
-      if (err?.code === 'ENOENT') {
+    child.on('error', (err: unknown) => {
+      const e = err as NodeJS.ErrnoException;
+      if (e?.code === 'ENOENT') {
         resolve(null);
       } else {
-        resolve({ stdout, stderr: err.message, code: 1 });
+        resolve({ stdout, stderr: e.message, code: 1 });
       }
     });
 

--- a/packages/gitcode/src/auth.ts
+++ b/packages/gitcode/src/auth.ts
@@ -1,91 +1,15 @@
-import { promises as fs } from 'fs';
-import { dirname, join } from 'path';
-import { homedir } from 'os';
 import { GitcodeClient } from './client';
+import { FileAuthStorage, defaultConfigPath } from './client/auth';
 
-export type AuthConfig = {
-  token?: string;
-  authStyle?: 'query' | 'bearer' | 'token' | 'header';
-  customAuthHeader?: string;
-};
-
-export interface AuthStorage {
-  read(): Promise<AuthConfig | null>;
-  write(cfg: AuthConfig): Promise<void>;
-  clear(): Promise<void>;
+export async function createGitcodeClient(): Promise<GitcodeClient> {
+  const storage = new FileAuthStorage(defaultConfigPath());
+  const envToken = process.env.GITCODE_TOKEN;
+  let token: string | null | undefined = envToken;
+  if (!token) {
+    const disk = (await storage.read()) || {};
+    token = disk.token ?? null;
+  }
+  return new GitcodeClient({ token: token ?? null });
 }
 
-export class FileAuthStorage implements AuthStorage {
-  constructor(private filePath: string) {}
-  async read(): Promise<AuthConfig | null> {
-    try {
-      const data = JSON.parse(await fs.readFile(this.filePath, 'utf8')) as AuthConfig;
-      return data;
-    } catch {
-      return null;
-    }
-  }
-  async write(cfg: AuthConfig): Promise<void> {
-    await fs.mkdir(dirname(this.filePath), { recursive: true });
-    await fs.writeFile(this.filePath, JSON.stringify(cfg, null, 2), {
-      encoding: 'utf8',
-      mode: 0o600 as number,
-    });
-  }
-  async clear(): Promise<void> {
-    try {
-      await fs.rm(this.filePath);
-    } catch {
-      // ignore
-    }
-  }
-}
-
-export function defaultConfigPath(): string {
-  // Store under ~/.gitany/gitcode/config.json on all platforms
-  const dir = join(homedir(), '.gitany', 'gitcode');
-  return join(dir, 'config.json');
-}
-
-export class GitcodeAuth {
-  private storage: AuthStorage;
-  constructor(storage: AuthStorage = new FileAuthStorage(defaultConfigPath())) {
-    this.storage = storage;
-  }
-
-  async setToken(token: string, authStyle?: AuthConfig['authStyle'], customAuthHeader?: string) {
-    const cfg: AuthConfig = { token, authStyle, customAuthHeader };
-    await this.storage.write(cfg);
-  }
-
-  async token(): Promise<string | null> {
-    const envToken = process.env.GITCODE_TOKEN;
-    // 优先从环境变量获取token
-    if (envToken) {
-      return envToken;
-    }
-
-    const disk = (await this.storage.read()) || {};
-
-    return disk.token || null;
-  }
-
-  async client(): Promise<GitcodeClient> {
-    const cfg = await this.load();
-    return new GitcodeClient({
-      token: cfg.token ?? null,
-    });
-  }
-
-  private async load(): Promise<AuthConfig> {
-    const envToken = process.env.GITCODE_TOKEN;
-    const envStyle = process.env.GITCODE_AUTH_STYLE as AuthConfig['authStyle'] | undefined;
-    const envHeader = process.env.GITCODE_AUTH_HEADER;
-    const disk = (await this.storage.read()) || {};
-    return {
-      token: envToken ?? disk.token,
-      authStyle: envStyle ?? disk.authStyle,
-      customAuthHeader: envHeader ?? disk.customAuthHeader,
-    };
-  }
-}
+export { FileAuthStorage, defaultConfigPath } from './client/auth';

--- a/packages/gitcode/src/client/auth/index.ts
+++ b/packages/gitcode/src/client/auth/index.ts
@@ -1,0 +1,85 @@
+import { promises as fs } from 'fs';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+import type { GitcodeClient } from '../core';
+
+export type AuthConfig = {
+  token?: string;
+  authStyle?: 'query' | 'bearer' | 'token' | 'header';
+  customAuthHeader?: string;
+};
+
+export interface AuthStorage {
+  read(): Promise<AuthConfig | null>;
+  write(cfg: AuthConfig): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class FileAuthStorage implements AuthStorage {
+  constructor(private filePath: string) {}
+
+  async read(): Promise<AuthConfig | null> {
+    try {
+      const data = JSON.parse(await fs.readFile(this.filePath, 'utf8')) as AuthConfig;
+      return data;
+    } catch {
+      return null;
+    }
+  }
+
+  async write(cfg: AuthConfig): Promise<void> {
+    await fs.mkdir(dirname(this.filePath), { recursive: true });
+    await fs.writeFile(this.filePath, JSON.stringify(cfg, null, 2), {
+      encoding: 'utf8',
+      mode: 0o600 as number,
+    });
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await fs.rm(this.filePath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function defaultConfigPath(): string {
+  const dir = join(homedir(), '.gitany', 'gitcode');
+  return join(dir, 'config.json');
+}
+
+export class GitcodeClientAuth {
+  private storage: AuthStorage;
+
+  constructor(
+    private client: GitcodeClient,
+    storage: AuthStorage = new FileAuthStorage(defaultConfigPath()),
+  ) {
+    this.storage = storage;
+  }
+
+  async setToken(
+    token: string,
+    authStyle?: AuthConfig['authStyle'],
+    customAuthHeader?: string,
+  ) {
+    const cfg: AuthConfig = { token, authStyle, customAuthHeader };
+    await this.storage.write(cfg);
+    this.client.setToken(token);
+  }
+
+  async token(): Promise<string | null> {
+    const envToken = process.env.GITCODE_TOKEN;
+    if (envToken) {
+      this.client.setToken(envToken);
+      return envToken;
+    }
+
+    const disk = (await this.storage.read()) || {};
+    const token = disk.token || null;
+    this.client.setToken(token);
+    return token;
+  }
+}
+

--- a/packages/gitcode/src/client/core.ts
+++ b/packages/gitcode/src/client/core.ts
@@ -4,16 +4,18 @@ export type GitcodeClientOptions = {
 };
 
 import { httpRequest, type HttpRequestOptions } from '../utils/http';
-import { GitCodeClientUser } from './user';
-import { GitCodeClientPr } from './pr';
-import { GitCodeClientRepo } from './repo';
+import { GitcodeClientUser } from './user';
+import { GitcodeClientPr } from './pr';
+import { GitcodeClientRepo } from './repo';
+import { GitcodeClientAuth } from './auth';
 
 export class GitcodeClient {
   private token: string | null;
 
-  pr = new GitCodeClientPr(this);
-  repo = new GitCodeClientRepo(this);
-  user = new GitCodeClientUser(this);
+  pr = new GitcodeClientPr(this);
+  repo = new GitcodeClientRepo(this);
+  user = new GitcodeClientUser(this);
+  auth = new GitcodeClientAuth(this);
 
   constructor(opts: GitcodeClientOptions = {}) {
     this.token = opts.token ?? null;

--- a/packages/gitcode/src/client/index.ts
+++ b/packages/gitcode/src/client/index.ts
@@ -2,3 +2,4 @@ export * from './core';
 export * from './repo';
 export * from './pr';
 export * from './user';
+export * from './auth';

--- a/packages/gitcode/src/client/pr/index.ts
+++ b/packages/gitcode/src/client/pr/index.ts
@@ -3,7 +3,7 @@ import { listPullRequests } from './list';
 import { createPullRequest } from './create';
 import type { ListPullsQuery, CreatePullBody } from '../../api/pr';
 
-export class GitCodeClientPr {
+export class GitcodeClientPr {
   constructor(private client: GitcodeClient) {}
 
   list(owner: string, repo: string, query: ListPullsQuery = { state: 'open' }) {

--- a/packages/gitcode/src/client/repo/index.ts
+++ b/packages/gitcode/src/client/repo/index.ts
@@ -3,9 +3,9 @@ import type { RepoRole } from '../../types/repo-role';
 import type { GitcodeClient } from '../core';
 import { getSelfRepoPermission, getSelfRepoPermissionRole } from './permission';
 
-export class GitCodeClientRepo {
+export class GitcodeClientRepo {
   constructor(private client: GitcodeClient) {}
-  
+
   async getSelfRepoPermission(owner: string, repo: string): Promise<SelfPermissionResponse> {
     return await getSelfRepoPermission(this.client, owner, repo);
   }

--- a/packages/gitcode/src/client/repo/permission.ts
+++ b/packages/gitcode/src/client/repo/permission.ts
@@ -39,12 +39,15 @@ export async function getSelfRepoPermissionRole(
 
 export function extractRepoRoleFromSelfPermission(result: unknown): RepoRole {
   if (result && typeof result === 'object') {
-    const obj: any = result;
-    const role = obj.role_info || obj.roleInfo;
+    const obj = result as Record<string, unknown>;
+    const role = (obj.role_info ?? obj.roleInfo) as Record<string, unknown> | undefined;
     if (!role) {
       return 'read';
     }
-    const cn = typeof role.cn_name === 'string' ? role.cn_name.trim() : '';
+    const cn =
+      typeof role.cn_name === 'string'
+        ? (role.cn_name as string).trim()
+        : '';
     if (cn.includes('管理员')) return 'admin';
     if (cn.includes('维护者') || cn.includes('开发者')) return 'write';
     return 'read';

--- a/packages/gitcode/src/client/user/index.ts
+++ b/packages/gitcode/src/client/user/index.ts
@@ -6,7 +6,7 @@ export async function getUserProfile(client: GitcodeClient): Promise<UserProfile
   return await client.request<UserProfileResponse>(url, 'GET', {});
 }
 
-export class GitCodeClientUser {
+export class GitcodeClientUser {
   constructor(private client: GitcodeClient) {}
 
   async getProfile(): Promise<UserProfileResponse> {

--- a/packages/gitcode/src/index.ts
+++ b/packages/gitcode/src/index.ts
@@ -23,7 +23,8 @@ export function parseGitUrl(url: string): Remote | null {
 export const version = '0.1.0';
 
 export { GitcodeClient } from './client';
-export { GitcodeAuth, FileAuthStorage, defaultConfigPath } from './auth';
+export { GitcodeClientAuth } from './client/auth';
+export { createGitcodeClient, FileAuthStorage, defaultConfigPath } from './auth';
 export type {
   SelfPermissionParams,
   RoleInfo,


### PR DESCRIPTION
## Summary
- migrate auth logic into `GitcodeClientAuth` submodule
- add `createGitcodeClient` helper and unify client naming
- update CLI commands and docs to use `client.auth`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c230c1ec288326bc1d96207bb7677b