### PR TITLE
feat: default GitClient run to instance cwd

### DIFF
--- a/docs/gitcode/pr.md
+++ b/docs/gitcode/pr.md
@@ -15,7 +15,8 @@ title: Pull Requests API
 
 - `ListPullsQuery`：PR 列表查询参数（`state`、`page`、`per_page`、`head`、`base` 等）。
 - `ListPullsParams`：包含 `owner`、`repo` 与可选 `query`。
-- `PullRequest`：PR 的最小字段表示（`id`、`number`、`title`、`state` 等）。
+- `Branch`：PR 分支信息结构（`label`、`ref`、`sha` 等）。
+- `PullRequest`：PR 的最小字段表示（`id`、`number`、`title`、`state`、`head`、`base` 等）。
 - `ListPullsResponse`：`PullRequest[]`。
 - `CreatePullBody`：创建 PR 可用字段（`title`、`head`、`base`、`body`、`issue`）。
 - `listPullsUrl(owner, repo)`：构建列表接口绝对 URL。

--- a/packages/git-lib/src/client/index.ts
+++ b/packages/git-lib/src/client/index.ts
@@ -3,10 +3,10 @@ import { gitStatus } from '../commands/status';
 import { gitShowFile } from '../commands/show';
 
 export class GitClient {
-  constructor(public cwd: string) {}
+  constructor(public cwd: string = process.cwd()) {}
 
-  async run(args: string[], options?: { cwd?: string }) {
-    return runGit(args, { cwd: options?.cwd });
+  async run(args: string[]) {
+    return runGit(args, { cwd: this.cwd });
   }
 
   async status() {

--- a/packages/gitcode/src/api/branch/index.ts
+++ b/packages/gitcode/src/api/branch/index.ts
@@ -1,4 +1,4 @@
-interface Branch {
+export interface Branch {
   label: string;
   ref: string;
   sha: string;

--- a/packages/gitcode/src/api/pr/list.ts
+++ b/packages/gitcode/src/api/pr/list.ts
@@ -40,6 +40,8 @@ export type ListPullsParams = {
  * Minimal Pull Request representation with common fields.
  * Additional fields may be present and are preserved via index signature.
  */
+import type { Branch } from '../branch';
+
 export type PullRequest = {
   id: number;
   number: number;


### PR DESCRIPTION
## Summary
- default `GitClient.cwd` to process working directory
- simplify `GitClient.run` to always use the instance `cwd`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c27450c7f48326a0c24e333c847ab4