### PR TITLE
feat(core): add askClaude helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { watchPullRequest } from './pr/watcher';
+export { askClaude, type AskClaudeOptions, type Permission } from './utils';

--- a/packages/core/src/utils/askClaude.ts
+++ b/packages/core/src/utils/askClaude.ts
@@ -1,0 +1,60 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+export type Permission = string;
+
+export interface AskClaudeOptions {
+  permissions?: Permission[];
+  anthropicBaseUrl?: string;
+  anthropicAuthToken?: string;
+  apiTimeoutMs?: number;
+  anthropicModel?: string;
+  anthropicSmallFastModel?: string;
+  disableNonessentialTraffic?: boolean;
+}
+
+const execFileAsync = promisify(execFile);
+
+export async function askClaude(
+  msg: string,
+  cwd: string,
+  options: AskClaudeOptions = {}
+): Promise<string> {
+  const {
+    permissions,
+    anthropicBaseUrl = process.env.ANTHROPIC_BASE_URL,
+    anthropicAuthToken = process.env.ANTHROPIC_AUTH_TOKEN,
+    apiTimeoutMs = Number(process.env.API_TIMEOUT_MS) || 60_000,
+    anthropicModel = process.env.ANTHROPIC_MODEL,
+    anthropicSmallFastModel = process.env.ANTHROPIC_SMALL_FAST_MODEL,
+    disableNonessentialTraffic =
+      process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC === '1',
+  } = options;
+
+  if (!anthropicAuthToken) {
+    throw new Error('ANTHROPIC_AUTH_TOKEN is required');
+  }
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(anthropicBaseUrl && { ANTHROPIC_BASE_URL: anthropicBaseUrl }),
+    ANTHROPIC_AUTH_TOKEN: anthropicAuthToken,
+    ...(apiTimeoutMs && { API_TIMEOUT_MS: String(apiTimeoutMs) }),
+    ...(anthropicModel && { ANTHROPIC_MODEL: anthropicModel }),
+    ...(anthropicSmallFastModel && {
+      ANTHROPIC_SMALL_FAST_MODEL: anthropicSmallFastModel,
+    }),
+    ...(disableNonessentialTraffic && {
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+    }),
+  };
+
+  const args = ['-p', msg, '--output-format', 'text'];
+  if (permissions && permissions.length > 0) {
+    args.push('--allowedTools', permissions.join(','));
+  }
+
+  const { stdout } = await execFileAsync('claude', args, { cwd, env });
+  return stdout.trim();
+}
+

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { askClaude, type AskClaudeOptions, type Permission } from './askClaude';


### PR DESCRIPTION
## Summary
- add askClaude helper to run Claude CLI in headless mode with env-based configuration
- clean up previous auto-translate scaffolding

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c2a1494f808326976afaae21296e71