### PR TITLE
feat: add docker test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepare": "husky",
     "dev:core": "pnpm --filter @gitany/core dev",
     "d": "pnpm build && node ./scripts/dev-gitcode.mjs",
-    "d:git": "pnpm build && node ./scripts/dev-git.mjs"
+    "d:git": "pnpm build && node ./scripts/dev-git.mjs",
+    "d:docker": "pnpm build && node ./scripts/dev-docker.mjs"
   },
   "devDependencies": {
     "husky": "^9.1.6",

--- a/scripts/dev-docker.mjs
+++ b/scripts/dev-docker.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'node:child_process';
+
+try {
+  const output = execSync('docker run --rm hello-world', {
+    encoding: 'utf8',
+  });
+  console.log(output);
+} catch (err) {
+  const msg = err.stderr?.toString().trim() || err.message;
+  console.error('Docker container failed to start:', msg);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `d:docker` command to run new container check script
- create `scripts/dev-docker.mjs` to verify Docker can start a container

## Testing
- `pnpm lint` *(fails: Unexpected any in packages/core/src/pr/watcher.ts)*
- `pnpm build`
- `node scripts/dev-docker.mjs` *(fails: /bin/sh: 1: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d288566c832697d186e537af87fa