### PR TITLE
feat(gitcode): add issue list API

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -98,6 +98,34 @@ gitcode pr create <url> --title "修复登录异常" --head feat/login-fix --bas
 - 字段支持（与 GitCode 文档对齐的子集）：`title`、`head`、`base`、`body`、`issue`
 - 调用：`POST /api/v5/repos/{owner}/{repo}/pulls`
 
+### gitcode issue list &lt;git-url&gt;
+
+列出指定仓库的 Issues。默认状态为 `open`，默认输出为「标题列表」：
+
+```
+- [#42] 修复登录异常
+- [#40] CI: 提升缓存命中率
+```
+
+```bash
+gitcode issue list https://gitcode.com/owner/repo.git
+
+# 带筛选参数：
+gitcode issue list git@gitcode.com:owner/repo.git \
+  --state open --labels bug,help-wanted --page 2 --per-page 50
+
+# 输出 JSON：
+gitcode issue list <url> --json
+```
+
+- 选项：
+  - `--state <state>`：`open | closed | all`（默认 `open`）
+  - `--labels <labels>`：以逗号分隔的标签列表
+  - `--page <n>`：页码
+  - `--per-page <n>`：每页数量
+  - `--json`：输出原始 JSON 数组
+- 调用：`GET /api/v5/repos/{owner}/{repo}/issues`
+
 ### gitcode user show
 
 显示当前认证用户的详细信息。

--- a/docs/gitcode/index.md
+++ b/docs/gitcode/index.md
@@ -19,7 +19,8 @@ title: gitcode 工具库
   - `listPullRequests(owner, repo, query?)`：获取仓库的 Pull Request 列表。
   - `createPullRequest(owner, repo, body)`：创建 Pull Request（支持字段：`title`、`head`、`base`、`body`、`issue`）。
   - `listPullRequestComments(url, prNumber, queryOptions?)`：获取指定 PR 的评论列表。
-  - 也可通过模块方式调用：`client.repo.getSelfRepoPermissionRole()`、`client.pr.list()`、`client.pr.create()`、`client.pr.comments()` 等。
+  - `listIssues(url, query?)`：获取仓库的 Issue 列表。
+  - 也可通过模块方式调用：`client.repo.getSelfRepoPermissionRole()`、`client.pr.list()`、`client.pr.create()`、`client.pr.comments()`、`client.issue.list()` 等。
 - `GitcodeClientAuth`
   - 通过 `client.auth` 提供本地令牌存储与加载。
 - `FileAuthStorage`、`defaultConfigPath()`
@@ -28,6 +29,7 @@ title: gitcode 工具库
 
 - 用户 API：见《[用户 API](./user.md)》。
 - Pull Requests：见《[Pull Requests API](./pr.md)》。
+- Issues：见《[Issues API](./issue.md)》。
 
 ## 公共类型
 
@@ -42,6 +44,10 @@ title: gitcode 工具库
 - `CreatePullBody`: 创建 PR 的字段（`title?`、`head?`、`base?`、`body?`、`issue?`）。
 - `PRComment`: PR 评论的类型定义，包含 `id`、`body`、`user` 等字段。
 - `PRCommentQueryOptions`: PR 评论查询选项，支持 `comment_type`（`diff_comment` | `pr_comment`）。
+- `ListIssuesQuery`: Issue 列表查询参数（`state`、`labels`、`page`、`per_page`）。
+- `ListIssuesParams`: Issue 列表路径参数（`owner`、`repo`、`query?`）。
+- `Issue`: Issue 的字段表示（`id`、`html_url`、`number`、`state`、`title`、`body`、`user`）。
+- `ListIssuesResponse`: `Issue[]`。
 
 ## 认证与请求
 
@@ -105,6 +111,9 @@ const pr = await client.createPullRequest('owner', 'repo', {
 const comments = await client.listPullRequestComments('https://gitcode.com/owner/repo.git', 123, {
   comment_type: 'pr_comment'
 });
+
+// 获取 Issue 列表（GET /repos/{owner}/{repo}/issues）
+const issues = await client.issue.list('https://gitcode.com/owner/repo.git', { state: 'open' });
 ```
 
 ## Git URL 解析
@@ -134,6 +143,10 @@ parseGitUrl('git@gitcode.com:owner/repo.git');
 
 - PR 列表、PR 评论和仓库权限接口的返回数据均通过 Zod 进行结构校验。
 - 自身权限接口在角色信息中保留 `cn_name` 字段以确保权限检测。
+
+### 2025-09-12 更新
+
+- 新增 Issue 列表 API 封装。
 
 ### 历史变更
 

--- a/docs/gitcode/issue.md
+++ b/docs/gitcode/issue.md
@@ -1,0 +1,45 @@
+---
+title: Issues API
+---
+
+# Issues
+
+提供与 Issue 相关的类型与路径构建工具，并通过 `GitcodeClient` 暴露便捷方法。
+
+适用接口：
+
+- 列表：GET `/api/v5/repos/{owner}/{repo}/issues`
+
+## 类型与导出
+
+- `ListIssuesQuery`：Issue 列表查询参数（`state`、`labels`、`page`、`per_page`）。
+- `ListIssuesParams`：包含 `owner`、`repo` 与可选 `query`。
+- `Issue`：Issue 的最小字段表示（`id`、`html_url`、`number`、`state`、`title`、`body`、`user`）。
+- `ListIssuesResponse`：`Issue[]`。
+- `listIssuesUrl(owner, repo)`：构建列表接口绝对 URL。
+
+以上均从包入口 `@gitany/gitcode` 导出。
+
+## 使用示例
+
+```ts
+import { GitcodeClient, listIssuesUrl } from '@gitany/gitcode';
+
+const client = new GitcodeClient({ token: process.env.GITCODE_TOKEN ?? null });
+
+// 1) 列表 Issues（通过 options.query 传参）
+const listUrl = listIssuesUrl('owner', 'repo');
+const issues = await client.request(listUrl, 'GET', {
+  query: { state: 'open', page: 1, per_page: 20, labels: 'bug' },
+});
+
+// 也可通过模块方式调用：
+const issues2 = await client.issue.list('https://gitcode.com/owner/repo.git', {
+  state: 'open',
+});
+```
+
+## 说明
+
+- 网络请求层统一由内部的 `utils/http.ts` 中的 `httpRequest` 处理，对外行为不变。
+- 字段与返回值与 GitCode 文档保持一致的最小子集，返回结果会通过 Zod 进行结构校验。

--- a/packages/cli/src/commands/issue/index.ts
+++ b/packages/cli/src/commands/issue/index.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+import { listCommand } from './list';
+
+export function issueCommand(): Command {
+  const issueProgram = new Command('issue')
+    .description('Issue commands');
+
+  issueProgram
+    .command('list')
+    .description('List issues for a repository')
+    .argument('<url>', 'Repository URL')
+    .option('--state <state>', 'Filter by state: open | closed | all', 'open')
+    .option('--labels <labels>', 'Comma-separated labels')
+    .option('--page <n>', 'Page number')
+    .option('--per-page <n>', 'Items per page')
+    .option('--json', 'Output raw JSON instead of list')
+    .action(listCommand);
+
+  return issueProgram;
+}

--- a/packages/cli/src/commands/issue/list.ts
+++ b/packages/cli/src/commands/issue/list.ts
@@ -1,0 +1,39 @@
+import { GitcodeClient } from '@gitany/gitcode';
+
+export async function listCommand(
+  url: string,
+  options: Record<string, string | undefined>,
+): Promise<void> {
+  try {
+    const client = new GitcodeClient();
+    const issues = await client.issue.list(url, {
+      state: options.state as 'open' | 'closed' | 'all' | undefined,
+      labels: options.labels,
+      page: options.page ? Number(options.page) : undefined,
+      per_page: options.perPage ? Number(options.perPage) : undefined,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(issues, null, 2));
+      return;
+    }
+
+    for (const issue of issues as unknown[]) {
+      const item = issue as Record<string, unknown>;
+      const num = (item.number ?? item.iid ?? item.id) as number | string | undefined;
+      const title = (item.title ?? item.subject ?? item.name ?? '(no title)') as string;
+      const numStr = typeof num === 'number' ? num : (num ?? '?');
+      console.log(`- [#${numStr}] ${title}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/\b404\b/.test(msg)) {
+      if (options.json) {
+        console.log('[]');
+      }
+      return;
+    }
+    console.error(err);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { authCommand } from './commands/auth';
 import { repoCommand } from './commands/repo';
 import { prCommand } from './commands/pr';
 import { userCommand } from './commands/user';
+import { issueCommand } from './commands/issue';
 
 const program = new Command();
 
@@ -37,5 +38,8 @@ program.addCommand(prCommand());
 
 // user command
 program.addCommand(userCommand());
+
+// issue command
+program.addCommand(issueCommand());
 
 program.parse();

--- a/packages/core/src/pr/watcher.ts
+++ b/packages/core/src/pr/watcher.ts
@@ -7,11 +7,12 @@ import { createRequire } from 'node:module';
 
 // Lazy pino logger (optional dependency). Falls back to console when unavailable.
 const __require = createRequire(import.meta.url);
-let logger: { error: (...args: any[]) => void } | null = null;
+let logger: { error: (...args: unknown[]) => void } | null = null;
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const pino = __require('pino');
-  const factory = (pino.default ?? pino) as (opts?: any) => { error: (...args: any[]) => void };
+  const factory = (pino.default ?? pino) as (opts?: unknown) => {
+    error: (...args: unknown[]) => void;
+  };
   logger = factory({ name: '@gitany/core' });
 } catch {
   logger = null;
@@ -189,7 +190,6 @@ function loadPersistedStateSync(url: string): WatcherState | null {
     if (logger) {
       logger.error({ url, err }, msg);
     } else {
-      // eslint-disable-next-line no-console
       console.error(msg, { url, err });
     }
     return null;
@@ -208,7 +208,6 @@ async function persistState(url: string, state: WatcherState) {
     await fs.writeFile(file, JSON.stringify(data), 'utf8');
   } catch (err) {
     // 忽略持久化错误，避免影响主流程，但应打印错误便于排查
-    // eslint-disable-next-line no-console
     console.error('[watchPullRequest] 持久化状态失败:', err);
   }
 }

--- a/packages/gitcode/src/api/issue/index.ts
+++ b/packages/gitcode/src/api/issue/index.ts
@@ -1,0 +1,11 @@
+export type {
+  ListIssuesQuery,
+  ListIssuesParams,
+  Issue,
+  ListIssuesResponse,
+} from './list';
+export {
+  listIssuesUrl,
+  issueSchema,
+  listIssuesResponseSchema,
+} from './list';

--- a/packages/gitcode/src/api/issue/list.ts
+++ b/packages/gitcode/src/api/issue/list.ts
@@ -39,7 +39,7 @@ export type ListIssuesParams = {
 export const issueSchema = z.object({
   id: z.number(),
   html_url: z.string(),
-  number: z.number(),
+  number: z.string(),
   state: z.string(),
   title: z.string(),
   body: z.string().nullable().optional(),

--- a/packages/gitcode/src/api/issue/list.ts
+++ b/packages/gitcode/src/api/issue/list.ts
@@ -1,0 +1,61 @@
+/**
+ * Issues - List
+ * Endpoint: GET /api/v5/repos/{owner}/{repo}/issues
+ */
+
+import { z } from 'zod';
+import { API_BASE } from '../constants';
+
+/**
+ * Query parameters for listing issues.
+ * Only include fields you need; extra fields are ignored.
+ */
+export interface ListIssuesQuery {
+  /** Filter by state: open | closed | all */
+  state?: 'open' | 'closed' | 'all';
+  /** Filter by labels (comma-separated). */
+  labels?: string;
+  /** Page index, starting from 1. */
+  page?: number;
+  /** Items per page. */
+  per_page?: number;
+}
+
+/**
+ * Path params for list issues request.
+ */
+export type ListIssuesParams = {
+  /** Repository owner (user or organization). */
+  owner: string;
+  /** Repository name (without .git). */
+  repo: string;
+  /** Optional query parameters. */
+  query?: ListIssuesQuery;
+};
+
+/**
+ * Minimal Issue representation with common fields.
+ */
+export const issueSchema = z.object({
+  id: z.number(),
+  html_url: z.string(),
+  number: z.number(),
+  state: z.string(),
+  title: z.string(),
+  body: z.string().nullable().optional(),
+  user: z.unknown().optional(),
+});
+
+export type Issue = z.infer<typeof issueSchema>;
+
+export const listIssuesResponseSchema = issueSchema.array();
+
+export type ListIssuesResponse = Issue[];
+
+/**
+ * Builds the request path for listing issues.
+ * Example: /repos/owner/repo/issues?state=open&page=1&per_page=20
+ */
+export function listIssuesUrl(owner: string, repo: string): string {
+  return `${API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`;
+}

--- a/packages/gitcode/src/client/core.ts
+++ b/packages/gitcode/src/client/core.ts
@@ -2,11 +2,13 @@ import { httpRequest, type HttpRequestOptions } from '../utils/http';
 import { GitcodeClientUser } from './user';
 import { GitcodeClientPr } from './pr';
 import { GitcodeClientRepo } from './repo';
+import { GitcodeClientIssue } from './issue';
 import { GitcodeClientAuth } from './auth';
 
 export class GitcodeClient {
   pr = new GitcodeClientPr(this);
   repo = new GitcodeClientRepo(this);
+  issue = new GitcodeClientIssue(this);
   user = new GitcodeClientUser(this);
   auth = new GitcodeClientAuth(this);
 

--- a/packages/gitcode/src/client/index.ts
+++ b/packages/gitcode/src/client/index.ts
@@ -1,5 +1,6 @@
 export * from './core';
 export * from './repo';
 export * from './pr';
+export * from './issue';
 export * from './user';
 export * from './auth';

--- a/packages/gitcode/src/client/issue/index.ts
+++ b/packages/gitcode/src/client/issue/index.ts
@@ -1,0 +1,13 @@
+import type { GitcodeClient } from '../core';
+import { listIssues } from './list';
+import type { ListIssuesQuery } from '../../api/issue';
+
+export class GitcodeClientIssue {
+  constructor(private client: GitcodeClient) {}
+
+  list(url: string, query: ListIssuesQuery = { state: 'open' }) {
+    return listIssues(this.client, url, query);
+  }
+}
+
+export { listIssues };

--- a/packages/gitcode/src/client/issue/list.ts
+++ b/packages/gitcode/src/client/issue/list.ts
@@ -1,0 +1,28 @@
+import {
+  listIssuesUrl,
+  type ListIssuesQuery,
+  type ListIssuesResponse,
+  listIssuesResponseSchema,
+} from '../../api/issue';
+import type { GitcodeClient } from '../core';
+import { parseGitUrl } from '../../utils';
+
+export async function listIssues(
+  client: GitcodeClient,
+  url: string,
+  query: ListIssuesQuery = { state: 'open' },
+): Promise<ListIssuesResponse> {
+  const parsed = parseGitUrl(url);
+  if (!parsed?.owner || !parsed?.repo) {
+    throw new Error(`Invalid Git URL: ${url}`);
+  }
+  const apiUrl = listIssuesUrl(parsed.owner, parsed.repo);
+  const q: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(query)) {
+    if (v !== undefined) {
+      q[k] = v;
+    }
+  }
+  const json = await client.request(apiUrl, 'GET', { query: q });
+  return listIssuesResponseSchema.parse(json);
+}

--- a/packages/gitcode/src/index.ts
+++ b/packages/gitcode/src/index.ts
@@ -32,6 +32,17 @@ export {
   prCommentsUrl,
 } from './api/pr';
 export type { PRComment, PRCommentQueryOptions } from './api/pr';
+export type {
+  ListIssuesQuery,
+  ListIssuesParams,
+  Issue,
+  ListIssuesResponse,
+} from './api/issue';
+export {
+  listIssuesUrl,
+  issueSchema,
+  listIssuesResponseSchema,
+} from './api/issue';
 export {
   userProfileSchema,
   userProfileUrl,


### PR DESCRIPTION
## Summary
- add issue listing schema, URL builder, and client helpers for Gitcode repos
- document issue API and update package exports
- fix watcher logger typings to satisfy lint

## Testing
- `pnpm build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4cfce7960832693df0348fe42fe21