### PR TITLE
feat: add issue comment listing

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -126,6 +126,30 @@ gitcode issue list <url> --json
   - `--json`：输出原始 JSON 数组
 - 调用：`GET /api/v5/repos/{owner}/{repo}/issues`
 
+### gitcode issue comments <git-url> <issue-number>
+
+列出指定 Issue 的评论。默认输出为「评论 ID 与首行内容」：
+
+```
+- [#123] 第一条评论
+```
+
+```bash
+gitcode issue comments https://gitcode.com/owner/repo.git 42
+
+# 带分页参数：
+gitcode issue comments <url> 42 --page 2 --per-page 50
+
+# 输出 JSON：
+gitcode issue comments <url> 42 --json
+```
+
+- 选项：
+  - `--page <n>`：页码
+  - `--per-page <n>`：每页数量
+  - `--json`：输出原始 JSON 数组
+- 调用：`GET /api/v5/repos/{owner}/{repo}/issues/{number}/comments`
+
 ### gitcode user show
 
 显示当前认证用户的详细信息。

--- a/docs/gitcode/issue.md
+++ b/docs/gitcode/issue.md
@@ -9,6 +9,7 @@ title: Issues API
 适用接口：
 
 - 列表：GET `/api/v5/repos/{owner}/{repo}/issues`
+- 评论：GET `/api/v5/repos/{owner}/{repo}/issues/{number}/comments`
 
 ## 类型与导出
 
@@ -16,7 +17,11 @@ title: Issues API
 - `ListIssuesParams`：包含 `owner`、`repo` 与可选 `query`。
 - `Issue`：Issue 的最小字段表示（`id`、`html_url`、`number`、`state`、`title`、`body`、`user`）。
 - `ListIssuesResponse`：`Issue[]`。
+- `IssueCommentsQuery`：Issue 评论查询参数（`page`、`per_page`）。
+- `IssueComment`：Issue 评论的最小字段表示（`id`、`body`、`user`）。
+- `IssueCommentsResponse`：`IssueComment[]`。
 - `listIssuesUrl(owner, repo)`：构建列表接口绝对 URL。
+- `issueCommentsUrl(owner, repo, number)`：构建评论列表接口绝对 URL。
 
 以上均从包入口 `@gitany/gitcode` 导出。
 
@@ -36,6 +41,12 @@ const issues = await client.request(listUrl, 'GET', {
 // 也可通过模块方式调用：
 const issues2 = await client.issue.list('https://gitcode.com/owner/repo.git', {
   state: 'open',
+});
+
+// 2) 列表 Issue 评论
+const comments = await client.issue.comments('https://gitcode.com/owner/repo.git', 42, {
+  page: 1,
+  per_page: 20,
 });
 ```
 

--- a/packages/cli/src/commands/issue/comments.ts
+++ b/packages/cli/src/commands/issue/comments.ts
@@ -1,0 +1,44 @@
+import { GitcodeClient } from '@gitany/gitcode';
+
+export async function commentsCommand(
+  url: string,
+  issueNumber: string,
+  options: Record<string, string | undefined>,
+): Promise<void> {
+  const n = Number(issueNumber);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error('Invalid issue number');
+    process.exit(1);
+    return;
+  }
+
+  try {
+    const client = new GitcodeClient();
+    const comments = await client.issue.comments(url, n, {
+      page: options.page ? Number(options.page) : undefined,
+      per_page: options.perPage ? Number(options.perPage) : undefined,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(comments, null, 2));
+      return;
+    }
+
+    for (const comment of comments as unknown[]) {
+      const item = comment as Record<string, unknown>;
+      const id = (item.id ?? item.comment_id ?? '?') as number | string;
+      const body = (item.body ?? '').toString().split('\n')[0];
+      console.log(`- [#${id}] ${body}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/\b404\b/.test(msg)) {
+      if (options.json) {
+        console.log('[]');
+      }
+      return;
+    }
+    console.error(err);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/issue/index.ts
+++ b/packages/cli/src/commands/issue/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { listCommand } from './list';
+import { commentsCommand } from './comments';
 
 export function issueCommand(): Command {
   const issueProgram = new Command('issue')
@@ -15,6 +16,16 @@ export function issueCommand(): Command {
     .option('--per-page <n>', 'Items per page')
     .option('--json', 'Output raw JSON instead of list')
     .action(listCommand);
+
+  issueProgram
+    .command('comments')
+    .description('List comments for an issue')
+    .argument('<url>', 'Repository URL')
+    .argument('<number>', 'Issue number')
+    .option('--page <n>', 'Page number')
+    .option('--per-page <n>', 'Items per page')
+    .option('--json', 'Output raw JSON instead of list')
+    .action(commentsCommand);
 
   return issueProgram;
 }

--- a/packages/gitcode/src/api/issue/comments.ts
+++ b/packages/gitcode/src/api/issue/comments.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue Comments - List
+ * Endpoint: GET /api/v5/repos/{owner}/{repo}/issues/{number}/comments
+ */
+
+import { z } from 'zod';
+import { API_BASE } from '../constants';
+
+/** Query parameters for listing issue comments. */
+export interface IssueCommentsQuery {
+  /** Page index, starting from 1. */
+  page?: number;
+  /** Items per page. */
+  per_page?: number;
+}
+
+/** Minimal Issue Comment representation. */
+export const issueCommentSchema = z.object({
+  id: z.number(),
+  body: z.string(),
+  user: z.unknown(),
+});
+
+export type IssueComment = z.infer<typeof issueCommentSchema>;
+
+export const issueCommentsResponseSchema = issueCommentSchema.array();
+
+export type IssueCommentsResponse = IssueComment[];
+
+/** Builds the request path for listing issue comments. */
+export function issueCommentsUrl(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): string {
+  return `${API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+    repo,
+  )}/issues/${issueNumber}/comments`;
+}
+

--- a/packages/gitcode/src/api/issue/index.ts
+++ b/packages/gitcode/src/api/issue/index.ts
@@ -9,3 +9,13 @@ export {
   issueSchema,
   listIssuesResponseSchema,
 } from './list';
+export type {
+  IssueCommentsQuery,
+  IssueComment,
+  IssueCommentsResponse,
+} from './comments';
+export {
+  issueCommentsUrl,
+  issueCommentSchema,
+  issueCommentsResponseSchema,
+} from './comments';

--- a/packages/gitcode/src/client/issue/comments.ts
+++ b/packages/gitcode/src/client/issue/comments.ts
@@ -1,0 +1,29 @@
+import {
+  issueCommentsUrl,
+  issueCommentSchema,
+  type IssueCommentsQuery,
+  type IssueComment,
+} from '../../api/issue';
+import type { GitcodeClient } from '../core';
+import { parseGitUrl } from '../../utils';
+
+export async function listIssueComments(
+  client: GitcodeClient,
+  url: string,
+  issueNumber: number,
+  query: IssueCommentsQuery = {},
+): Promise<IssueComment[]> {
+  const parsed = parseGitUrl(url);
+  if (!parsed?.owner || !parsed?.repo) {
+    throw new Error(`Invalid Git URL: ${url}`);
+  }
+  const apiUrl = issueCommentsUrl(parsed.owner, parsed.repo, issueNumber);
+  const q: Record<string, string | number | boolean> = {};
+  for (const [k, v] of Object.entries(query)) {
+    if (v !== undefined) {
+      q[k] = v;
+    }
+  }
+  const json = await client.request(apiUrl, 'GET', { query: q });
+  return issueCommentSchema.array().parse(json);
+}

--- a/packages/gitcode/src/client/issue/index.ts
+++ b/packages/gitcode/src/client/issue/index.ts
@@ -1,6 +1,7 @@
 import type { GitcodeClient } from '../core';
 import { listIssues } from './list';
-import type { ListIssuesQuery } from '../../api/issue';
+import { listIssueComments } from './comments';
+import type { ListIssuesQuery, IssueCommentsQuery } from '../../api/issue';
 
 export class GitcodeClientIssue {
   constructor(private client: GitcodeClient) {}
@@ -8,6 +9,10 @@ export class GitcodeClientIssue {
   list(url: string, query: ListIssuesQuery = { state: 'open' }) {
     return listIssues(this.client, url, query);
   }
+
+  comments(url: string, issueNumber: number, query: IssueCommentsQuery = {}) {
+    return listIssueComments(this.client, url, issueNumber, query);
+  }
 }
 
-export { listIssues };
+export { listIssues, listIssueComments };

--- a/packages/gitcode/src/index.ts
+++ b/packages/gitcode/src/index.ts
@@ -37,11 +37,17 @@ export type {
   ListIssuesParams,
   Issue,
   ListIssuesResponse,
+  IssueCommentsQuery,
+  IssueComment,
+  IssueCommentsResponse,
 } from './api/issue';
 export {
   listIssuesUrl,
   issueSchema,
   listIssuesResponseSchema,
+  issueCommentsUrl,
+  issueCommentSchema,
+  issueCommentsResponseSchema,
 } from './api/issue';
 export {
   userProfileSchema,


### PR DESCRIPTION
## Summary
- expose issue comment listing in gitcode client and API
- support `gitcode issue comments` command
- document issue comment usage and CLI examples

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c4d72e151c83269545c23c8d4e3e88