### PR TITLE
feat(cli): auto detect repository url

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -22,12 +22,15 @@ pnpm --filter @gitany/cli start -- --help
 
 ## 命令
 
-### gitcode parse &lt;git-url&gt;
+### gitcode parse [git-url]
 
-解析 Git 远程地址并输出 JSON。
+解析 Git 远程地址并输出 JSON。若未提供 `git-url`，将自动检测当前目录下名为 `origin` 的远程地址。
 
 ```bash
 gitcode parse https://gitcode.com/owner/repo.git
+
+# 自动检测当前仓库
+gitcode parse
 ```
 
 ### gitcode auth &lt;subcommand&gt;
@@ -37,20 +40,23 @@ gitcode parse https://gitcode.com/owner/repo.git
 - `set-token <token>`
   - 行为：保存令牌到本地配置文件。
 
-### gitcode repo permission &lt;git-url&gt;
+### gitcode repo permission [git-url]
 
-查询当前登录用户在指定仓库（通过仓库链接）的权限。
+查询当前登录用户在指定仓库（通过仓库链接）的权限。若未提供 `git-url`，将使用当前目录下 `origin` 远程地址。
 
 ```bash
 gitcode repo permission https://gitcode.com/owner/repo.git
+
+# 自动检测当前仓库
+gitcode repo permission
 ```
 
 - 调用：`GET /api/v5/repos/{owner}/{repo}/collaborators/self-permission`
 - 输出：固定为一个词：`admin | write | read | none`（仓库不存在时返回 `none`）
 
-### gitcode pr list &lt;git-url&gt;
+### gitcode pr list [git-url]
 
-列出指定仓库的 Pull Requests。默认状态为 `open`，默认输出为「标题列表」：
+列出指定仓库的 Pull Requests。默认状态为 `open`，默认输出为「标题列表」。若未提供 `git-url`，将使用当前目录下 `origin` 远程地址：
 
 ```
 - [#18] 修复登录异常
@@ -59,6 +65,9 @@ gitcode repo permission https://gitcode.com/owner/repo.git
 
 ```bash
 gitcode pr list https://gitcode.com/owner/repo.git
+
+# 自动检测当前仓库
+gitcode pr list
 
 # 带筛选参数：
 gitcode pr list git@gitcode.com:owner/repo.git \
@@ -76,13 +85,16 @@ gitcode pr list <url> --json
   - `--json`：输出原始 JSON 数组
 - 调用：`GET /api/v5/repos/{owner}/{repo}/pulls`
 
-### gitcode pr create &lt;git-url&gt;
+### gitcode pr create [git-url]
 
-创建 Pull Request（仅支持部分字段）。
+创建 Pull Request（仅支持部分字段）。若未提供 `git-url`，将使用当前目录下 `origin` 远程地址。
 
 ```bash
 gitcode pr create https://gitcode.com/owner/repo.git \
   --title "修复登录异常" --head feat/login-fix --base main --body "补充说明：修复 Token 过期报错"
+
+# 自动检测当前仓库
+gitcode pr create --title "修复登录异常" --head feat/login-fix --base main
 
 # 关联 Issue（示例）：
 gitcode pr create <url> --title "修复登录异常" --head feat/login-fix --base main --issue 123
@@ -98,9 +110,9 @@ gitcode pr create <url> --title "修复登录异常" --head feat/login-fix --bas
 - 字段支持（与 GitCode 文档对齐的子集）：`title`、`head`、`base`、`body`、`issue`
 - 调用：`POST /api/v5/repos/{owner}/{repo}/pulls`
 
-### gitcode issue list &lt;git-url&gt;
+### gitcode issue list [git-url]
 
-列出指定仓库的 Issues。默认状态为 `open`，默认输出为「标题列表」：
+列出指定仓库的 Issues。默认状态为 `open`，默认输出为「标题列表」。若未提供 `git-url`，将使用当前目录下 `origin` 远程地址：
 
 ```
 - [#42] 修复登录异常
@@ -109,6 +121,9 @@ gitcode pr create <url> --title "修复登录异常" --head feat/login-fix --bas
 
 ```bash
 gitcode issue list https://gitcode.com/owner/repo.git
+
+# 自动检测当前仓库
+gitcode issue list
 
 # 带筛选参数：
 gitcode issue list git@gitcode.com:owner/repo.git \
@@ -126,9 +141,9 @@ gitcode issue list <url> --json
   - `--json`：输出原始 JSON 数组
 - 调用：`GET /api/v5/repos/{owner}/{repo}/issues`
 
-### gitcode issue comments <git-url> <issue-number>
+### gitcode issue comments [git-url] <issue-number>
 
-列出指定 Issue 的评论。默认输出为「评论 ID 与首行内容」：
+列出指定 Issue 的评论。默认输出为「评论 ID 与首行内容」。若未提供 `git-url`，将使用当前目录下 `origin` 远程地址：
 
 ```
 - [#123] 第一条评论
@@ -136,6 +151,9 @@ gitcode issue list <url> --json
 
 ```bash
 gitcode issue comments https://gitcode.com/owner/repo.git 42
+
+# 自动检测当前仓库
+gitcode issue comments 42
 
 # 带分页参数：
 gitcode issue comments <url> 42 --page 2 --per-page 50

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@gitany/gitcode": "workspace:*",
     "@gitany/shared": "workspace:*",
+    "@gitany/git-lib": "workspace:*",
     "commander": "^14.0.0"
   },
   "engines": {

--- a/packages/cli/src/commands/issue/index.ts
+++ b/packages/cli/src/commands/issue/index.ts
@@ -9,7 +9,7 @@ export function issueCommand(): Command {
   issueProgram
     .command('list')
     .description('List issues for a repository')
-    .argument('<url>', 'Repository URL')
+    .argument('[url]', 'Repository URL')
     .option('--state <state>', 'Filter by state: open | closed | all', 'open')
     .option('--labels <labels>', 'Comma-separated labels')
     .option('--page <n>', 'Page number')
@@ -20,8 +20,8 @@ export function issueCommand(): Command {
   issueProgram
     .command('comments')
     .description('List comments for an issue')
-    .argument('<url>', 'Repository URL')
-    .argument('<number>', 'Issue number')
+    .argument('[url]', 'Repository URL')
+    .argument('[number]', 'Issue number')
     .option('--page <n>', 'Page number')
     .option('--per-page <n>', 'Items per page')
     .option('--json', 'Output raw JSON instead of list')

--- a/packages/cli/src/commands/issue/list.ts
+++ b/packages/cli/src/commands/issue/list.ts
@@ -1,15 +1,17 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '../../utils';
 
 const logger = createLogger('@gitany/cli');
 
 export async function listCommand(
-  url: string,
+  url: string | undefined,
   options: Record<string, string | undefined>,
 ): Promise<void> {
   try {
+    const repoUrl = await resolveRepoUrl(url);
     const client = new GitcodeClient();
-    const issues = await client.issue.list(url, {
+    const issues = await client.issue.list(repoUrl, {
       state: options.state as 'open' | 'closed' | 'all' | undefined,
       labels: options.labels,
       page: options.page ? Number(options.page) : undefined,

--- a/packages/cli/src/commands/pr/create.ts
+++ b/packages/cli/src/commands/pr/create.ts
@@ -1,10 +1,11 @@
 import { GitcodeClient, type CreatePullBody } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '../../utils';
 
 const logger = createLogger('@gitany/cli');
 
 export async function createCommand(
-  url: string,
+  url: string | undefined,
   options: Record<string, string | undefined>,
 ): Promise<void> {
   try {
@@ -25,8 +26,9 @@ export async function createCommand(
       body.issue = n;
     }
 
+    const repoUrl = await resolveRepoUrl(url);
     const client = new GitcodeClient();
-    const created = await client.pr.create(url, body);
+    const created = await client.pr.create(repoUrl, body);
 
     if (options.json) {
       console.log(JSON.stringify(created, null, 2));

--- a/packages/cli/src/commands/pr/index.ts
+++ b/packages/cli/src/commands/pr/index.ts
@@ -9,7 +9,7 @@ export function prCommand(): Command {
   prProgram
     .command('list')
     .description('List pull requests for a repository')
-    .argument('<url>', 'Repository URL')
+    .argument('[url]', 'Repository URL')
     .option('--state <state>', 'Filter by state: open | closed | all', 'open')
     .option('--head <ref>', 'Filter by head (branch or repo:branch)')
     .option('--base <branch>', 'Filter by base branch')
@@ -21,7 +21,7 @@ export function prCommand(): Command {
   prProgram
     .command('create')
     .description('Create a new pull request')
-    .argument('<url>', 'Repository URL')
+    .argument('[url]', 'Repository URL')
     .requiredOption('--title <title>', 'Title of the PR')
     .requiredOption('--head <branch>', 'Source branch name')
     .option('--base <branch>', 'Target branch')

--- a/packages/cli/src/commands/pr/list.ts
+++ b/packages/cli/src/commands/pr/list.ts
@@ -1,15 +1,17 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '../../utils';
 
 const logger = createLogger('@gitany/cli');
 
 export async function listCommand(
-  url: string,
+  url: string | undefined,
   options: Record<string, string | undefined>,
 ): Promise<void> {
   try {
+    const repoUrl = await resolveRepoUrl(url);
     const client = new GitcodeClient();
-    const pulls = await client.pr.list(url, {
+    const pulls = await client.pr.list(repoUrl, {
       state: options.state,
       head: options.head,
       base: options.base,

--- a/packages/cli/src/commands/repo/index.ts
+++ b/packages/cli/src/commands/repo/index.ts
@@ -6,7 +6,7 @@ export function repoCommand(): Command {
     .description('Repository commands');
 
   repoProgram
-    .command('permission <url>')
+    .command('permission [url]')
     .description('Show current user\'s role on a repo')
     .action(permissionCommand);
 

--- a/packages/cli/src/commands/repo/permission.ts
+++ b/packages/cli/src/commands/repo/permission.ts
@@ -1,12 +1,14 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '../../utils';
 
 const logger = createLogger('@gitany/cli');
 
-export async function permissionCommand(url: string): Promise<void> {
+export async function permissionCommand(url?: string): Promise<void> {
   try {
+    const repoUrl = await resolveRepoUrl(url);
     const client = new GitcodeClient();
-    const permission = await client.repo.getSelfRepoPermissionRole(url);
+    const permission = await client.repo.getSelfRepoPermissionRole(repoUrl);
     console.log(permission);
   } catch (err) {
     logger.error({ err }, 'Failed to get repo permission');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { repoCommand } from './commands/repo';
 import { prCommand } from './commands/pr';
 import { userCommand } from './commands/user';
 import { issueCommand } from './commands/issue';
+import { resolveRepoUrl } from './utils';
 
 const program = new Command();
 const logger = createLogger('@gitany/cli');
@@ -18,15 +19,21 @@ program
 
 // parse command
 program
-  .command('parse <url>')
+  .command('parse [url]')
   .description('Parse Git URL and output JSON')
-  .action((url) => {
-    const parsed = parseGitUrl(url);
-    if (!parsed) {
-      logger.error({ url }, 'Unrecognized git URL');
+  .action(async (url) => {
+    try {
+      const resolved = await resolveRepoUrl(url);
+      const parsed = parseGitUrl(resolved);
+      if (!parsed) {
+        logger.error({ url: resolved }, 'Unrecognized git URL');
+        process.exit(1);
+      }
+      console.log(JSON.stringify(parsed, null, 2));
+    } catch (err) {
+      logger.error({ err }, 'Failed to resolve repository URL');
       process.exit(1);
     }
-    console.log(JSON.stringify(parsed, null, 2));
   });
 
 // auth command

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,0 +1,11 @@
+import { GitClient } from '@gitany/git-lib';
+
+export async function resolveRepoUrl(url?: string): Promise<string> {
+  if (url) return url;
+  const git = new GitClient();
+  const result = await git.run(['remote', 'get-url', 'origin']);
+  if (!result || result.code !== 0) {
+    throw new Error('Failed to detect repository URL from git remote "origin"');
+  }
+  return result.stdout.trim();
+}


### PR DESCRIPTION
## Summary
- allow CLI commands to omit URL and resolve from current repo's `origin`
- document optional URL usage across CLI commands

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e8dee8308326b37898d2cf0d8732