### PR TITLE
feat(cli): default to git remote when url missing

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -22,12 +22,18 @@ pnpm --filter @gitany/cli start -- --help
 
 ## 命令
 
-### gitcode parse &lt;git-url&gt;
+> 在 Git 仓库目录中执行命令且不传入 URL 参数时，CLI 会通过 `@gitany/git-lib` 的 `resolveRepoUrl` 自动使用 `git remote get-url origin` 获取仓库地址。
+
+### gitcode parse [git-url]
 
 解析 Git 远程地址并输出 JSON。
 
 ```bash
+# 显式传入 URL
 gitcode parse https://gitcode.com/owner/repo.git
+
+# 在当前 Git 仓库中自动获取 remote
+gitcode parse
 ```
 
 ### gitcode auth &lt;subcommand&gt;
@@ -41,12 +47,14 @@ gitcode parse https://gitcode.com/owner/repo.git
 
 仓库相关命令。
 
-#### gitcode repo permission &lt;git-url&gt;
+#### gitcode repo permission [git-url]
 
 查询当前登录用户在指定仓库（通过仓库链接）的权限。
 
 ```bash
 gitcode repo permission https://gitcode.com/owner/repo.git
+# 或者在仓库目录中直接运行
+gitcode repo permission
 ```
 
 - 调用：`GET /api/v5/repos/{owner}/{repo}/collaborators/self-permission`
@@ -162,7 +170,7 @@ gitcode repo info webhooks myorg myrepo
 
 Pull Request 相关命令。
 
-#### gitcode pr list &lt;git-url&gt;
+#### gitcode pr list [git-url]
 
 列出指定仓库的 Pull Requests。默认状态为 `open`，默认输出为「标题列表」：
 
@@ -173,6 +181,9 @@ Pull Request 相关命令。
 
 ```bash
 gitcode pr list https://gitcode.com/owner/repo.git
+
+# 或者在仓库目录中直接运行
+gitcode pr list
 
 # 带筛选参数：
 gitcode pr list git@gitcode.com:owner/repo.git \
@@ -190,13 +201,16 @@ gitcode pr list <url> --json
   - `--json`：输出原始 JSON 数组
 - 调用：`GET /api/v5/repos/{owner}/{repo}/pulls`
 
-### gitcode pr create &lt;git-url&gt;
+### gitcode pr create [git-url]
 
 创建 Pull Request（仅支持部分字段）。
 
 ```bash
 gitcode pr create https://gitcode.com/owner/repo.git \
   --title "修复登录异常" --head feat/login-fix --base main --body "补充说明：修复 Token 过期报错"
+
+# 或者在仓库目录中直接运行
+gitcode pr create --title "修复登录异常" --head feat/login-fix --base main
 
 # 关联 Issue（示例）：
 gitcode pr create <url> --title "修复登录异常" --head feat/login-fix --base main --issue 123
@@ -237,7 +251,7 @@ PR 设置:
 
 - 调用：`GET /api/v5/repos/{owner}/{repo}/pull_request_settings`
 
-### gitcode issue list &lt;git-url&gt;
+### gitcode issue list [git-url]
 
 列出指定仓库的 Issues。默认状态为 `open`，默认输出为「标题列表」：
 
@@ -248,6 +262,9 @@ PR 设置:
 
 ```bash
 gitcode issue list https://gitcode.com/owner/repo.git
+
+# 或者在仓库目录中直接运行
+gitcode issue list
 
 # 带筛选参数：
 gitcode issue list git@gitcode.com:owner/repo.git \
@@ -265,7 +282,7 @@ gitcode issue list <url> --json
   - `--json`：输出原始 JSON 数组
 - 调用：`GET /api/v5/repos/{owner}/{repo}/issues`
 
-### gitcode issue comments <git-url> <issue-number>
+### gitcode issue comments <issue-number> [git-url]
 
 列出指定 Issue 的评论。默认输出为「评论 ID 与首行内容」：
 
@@ -274,13 +291,16 @@ gitcode issue list <url> --json
 ```
 
 ```bash
-gitcode issue comments https://gitcode.com/owner/repo.git 42
+gitcode issue comments 42 https://gitcode.com/owner/repo.git
+
+# 或者在仓库目录中直接运行
+gitcode issue comments 42
 
 # 带分页参数：
-gitcode issue comments <url> 42 --page 2 --per-page 50
+gitcode issue comments 42 --page 2 --per-page 50
 
 # 输出 JSON：
-gitcode issue comments <url> 42 --json
+gitcode issue comments 42 --json
 ```
 
 - 选项：

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@gitany/gitcode": "workspace:*",
+    "@gitany/git-lib": "workspace:*",
     "@gitany/shared": "workspace:*",
     "commander": "^14.0.0"
   },

--- a/packages/cli/src/commands/issue/comments.ts
+++ b/packages/cli/src/commands/issue/comments.ts
@@ -1,12 +1,13 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 const logger = createLogger('@gitany/cli');
 
 export async function commentsCommand(
-  url: string,
   issueNumber: string,
-  options: Record<string, string | undefined>,
+  url?: string,
+  options: Record<string, string | undefined> = {},
 ): Promise<void> {
   const n = Number(issueNumber);
   if (!Number.isFinite(n) || n <= 0) {
@@ -16,11 +17,12 @@ export async function commentsCommand(
   }
 
   try {
-    const client = new GitcodeClient();
-    const comments = await client.issue.comments(url, n, {
-      page: options.page ? Number(options.page) : undefined,
-      per_page: options.perPage ? Number(options.perPage) : undefined,
-    });
+      const client = new GitcodeClient();
+      const repoUrl = await resolveRepoUrl(url);
+      const comments = await client.issue.comments(repoUrl, n, {
+        page: options.page ? Number(options.page) : undefined,
+        per_page: options.perPage ? Number(options.perPage) : undefined,
+      });
 
     if (options.json) {
       console.log(JSON.stringify(comments, null, 2));

--- a/packages/cli/src/commands/issue/index.ts
+++ b/packages/cli/src/commands/issue/index.ts
@@ -14,7 +14,7 @@ export function issueCommand(): Command {
     .command('list')
     .alias('ls')
     .description('List issues for a repository')
-    .argument('<url>', 'Repository URL')
+    .argument('[url]', 'Repository URL')
     .option('-s, --state <state>', 'Filter by state: open | closed | all', 'open')
     .option('--labels <labels>', 'Comma-separated labels')
     .option('--page <n>', 'Page number')
@@ -26,12 +26,12 @@ export function issueCommand(): Command {
   issueProgram
     .command('comments')
     .description('List comments for an issue')
-    .argument('<url>', 'Repository URL')
     .argument('<number>', 'Issue number')
+    .argument('[url]', 'Repository URL')
     .option('--page <n>', 'Page number')
     .option('--per-page <n>', 'Items per page')
     .option('--json', 'Output raw JSON instead of list')
-    .action(commentsCommand);
+    .action((number, url, options) => commentsCommand(number, url, options));
 
   // Create issue command with GitHub CLI style options
   issueProgram.addCommand(createCommand());

--- a/packages/cli/src/commands/issue/list.ts
+++ b/packages/cli/src/commands/issue/list.ts
@@ -1,15 +1,17 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 const logger = createLogger('@gitany/cli');
 
 export async function listCommand(
-  url: string,
-  options: Record<string, string | undefined>,
+  url?: string,
+  options: Record<string, string | undefined> = {},
 ): Promise<void> {
   try {
     const client = new GitcodeClient();
-    const issues = await client.issue.list(url, {
+    const repoUrl = await resolveRepoUrl(url);
+    const issues = await client.issue.list(repoUrl, {
       state: options.state as 'open' | 'closed' | 'all' | undefined,
       labels: options.labels,
       page: options.page ? Number(options.page) : undefined,

--- a/packages/cli/src/commands/issue/status.ts
+++ b/packages/cli/src/commands/issue/status.ts
@@ -1,19 +1,20 @@
 import { Command } from 'commander';
 import { GitcodeClient } from '@gitany/gitcode';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 interface StatusOptions {
   json?: boolean;
   repo?: string;
 }
 
-export async function statusAction(url: string, options: StatusOptions = {}) {
+export async function statusAction(urlArg?: string, options: StatusOptions = {}) {
   try {
     const client = new GitcodeClient();
-    
+
     // 解析 repository URL
     let owner: string;
     let repo: string;
-    
+
     if (options.repo) {
       const repoMatch = options.repo.match(/^(?:https?:\/\/)?([^/]+)\/([^/]+)(?:\.git)?$/);
       if (repoMatch) {
@@ -29,6 +30,7 @@ export async function statusAction(url: string, options: StatusOptions = {}) {
         }
       }
     } else {
+      const url = await resolveRepoUrl(urlArg);
       const urlMatch = url.match(/^(?:https?:\/\/)?([^/]+)\/([^/]+)(?:\.git)?$/);
       if (urlMatch) {
         owner = urlMatch[1];
@@ -114,7 +116,7 @@ export function statusCommand(): Command {
   return new Command('status')
     .alias('st')
     .description('Show issue status and statistics for a repository')
-    .argument('<url>', 'Repository URL or OWNER/REPO')
+    .argument('[url]', 'Repository URL or OWNER/REPO')
     .option('--json', 'Output raw JSON instead of formatted status')
     .option('-R, --repo <[HOST/]OWNER/REPO>', 'Select another repository using the [HOST/]OWNER/REPO format')
     .action(statusAction);

--- a/packages/cli/src/commands/pr/create.ts
+++ b/packages/cli/src/commands/pr/create.ts
@@ -1,11 +1,12 @@
 import { GitcodeClient, type CreatePullBody } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 const logger = createLogger('@gitany/cli');
 
 export async function createCommand(
-  url: string,
-  options: Record<string, string | undefined>,
+  url?: string,
+  options: Record<string, string | undefined> = {},
 ): Promise<void> {
   try {
     const body: CreatePullBody = {
@@ -26,7 +27,8 @@ export async function createCommand(
     }
 
     const client = new GitcodeClient();
-    const created = await client.pr.create(url, body);
+    const repoUrl = await resolveRepoUrl(url);
+    const created = await client.pr.create(repoUrl, body);
 
     if (options.json) {
       console.log(JSON.stringify(created, null, 2));

--- a/packages/cli/src/commands/pr/index.ts
+++ b/packages/cli/src/commands/pr/index.ts
@@ -7,11 +7,11 @@ export function prCommand(): Command {
   const prProgram = new Command('pr')
     .description('Pull request commands');
 
-  prProgram
-    .command('list')
-    .description('List pull requests for a repository')
-    .argument('<url>', 'Repository URL')
-    .option('--state <state>', 'Filter by state: open | closed | all', 'open')
+    prProgram
+      .command('list')
+      .description('List pull requests for a repository')
+      .argument('[url]', 'Repository URL')
+      .option('--state <state>', 'Filter by state: open | closed | all', 'open')
     .option('--head <ref>', 'Filter by head (branch or repo:branch)')
     .option('--base <branch>', 'Filter by base branch')
     .option('--sort <field>', 'Optional sort field if supported')
@@ -19,10 +19,10 @@ export function prCommand(): Command {
     .option('--json', 'Output raw JSON instead of list')
     .action(listCommand);
 
-  prProgram
-    .command('create')
-    .description('Create a new pull request')
-    .argument('<url>', 'Repository URL')
+    prProgram
+      .command('create')
+      .description('Create a new pull request')
+      .argument('[url]', 'Repository URL')
     .requiredOption('--title <title>', 'Title of the PR')
     .requiredOption('--head <branch>', 'Source branch name')
     .option('--base <branch>', 'Target branch')

--- a/packages/cli/src/commands/pr/list.ts
+++ b/packages/cli/src/commands/pr/list.ts
@@ -1,15 +1,17 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 const logger = createLogger('@gitany/cli');
 
 export async function listCommand(
-  url: string,
-  options: Record<string, string | undefined>,
+  url?: string,
+  options: Record<string, string | undefined> = {},
 ): Promise<void> {
   try {
     const client = new GitcodeClient();
-    const pulls = await client.pr.list(url, {
+    const repoUrl = await resolveRepoUrl(url);
+    const pulls = await client.pr.list(repoUrl, {
       state: options.state,
       head: options.head,
       base: options.base,

--- a/packages/cli/src/commands/repo/index.ts
+++ b/packages/cli/src/commands/repo/index.ts
@@ -7,7 +7,7 @@ export function repoCommand(): Command {
     .description('Repository commands');
 
   repoProgram
-    .command('permission <url>')
+    .command('permission [url]')
     .description('Show current user\'s role on a repo')
     .action(permissionCommand);
 

--- a/packages/cli/src/commands/repo/permission.ts
+++ b/packages/cli/src/commands/repo/permission.ts
@@ -1,12 +1,14 @@
 import { GitcodeClient } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 const logger = createLogger('@gitany/cli');
 
-export async function permissionCommand(url: string): Promise<void> {
+export async function permissionCommand(url?: string): Promise<void> {
   try {
     const client = new GitcodeClient();
-    const permission = await client.repo.getSelfRepoPermissionRole(url);
+    const repoUrl = await resolveRepoUrl(url);
+    const permission = await client.repo.getSelfRepoPermissionRole(repoUrl);
     console.log(permission);
   } catch (err) {
     logger.error({ err }, 'Failed to get repo permission');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { repoCommand } from './commands/repo';
 import { prCommand } from './commands/pr';
 import { userCommand } from './commands/user';
 import { issueCommand } from './commands/issue';
+import { resolveRepoUrl } from '@gitany/git-lib';
 
 const program = new Command();
 const logger = createLogger('@gitany/cli');
@@ -18,15 +19,21 @@ program
 
 // parse command
 program
-  .command('parse <url>')
+  .command('parse [url]')
   .description('Parse Git URL and output JSON')
-  .action((url) => {
-    const parsed = parseGitUrl(url);
-    if (!parsed) {
-      logger.error({ url }, 'Unrecognized git URL');
+  .action(async (url?: string) => {
+    try {
+      const repoUrl = await resolveRepoUrl(url);
+      const parsed = parseGitUrl(repoUrl);
+      if (!parsed) {
+        logger.error({ url: repoUrl }, 'Unrecognized git URL');
+        process.exit(1);
+      }
+      console.log(JSON.stringify(parsed, null, 2));
+    } catch (err) {
+      logger.error({ err }, 'Failed to parse git URL');
       process.exit(1);
     }
-    console.log(JSON.stringify(parsed, null, 2));
   });
 
 // auth command

--- a/packages/git-lib/src/index.ts
+++ b/packages/git-lib/src/index.ts
@@ -1,2 +1,3 @@
 export type { GitResult, GitExecOptions } from './types';
 export { GitClient } from './client';
+export { resolveRepoUrl } from './utils';

--- a/packages/git-lib/src/utils/index.ts
+++ b/packages/git-lib/src/utils/index.ts
@@ -1,6 +1,8 @@
 import os from 'node:os';
 import path from 'node:path';
 
+export { resolveRepoUrl } from './resolve-repo-url';
+
 export function expandCwd(cwd?: string) {
   if (!cwd) return cwd;
   if (cwd.startsWith('~')) {

--- a/packages/git-lib/src/utils/resolve-repo-url.ts
+++ b/packages/git-lib/src/utils/resolve-repo-url.ts
@@ -1,0 +1,13 @@
+import { GitClient } from '../client';
+
+export async function resolveRepoUrl(url?: string, options: { cwd?: string } = {}): Promise<string> {
+  if (url) return url;
+  const client = new GitClient(options.cwd);
+  const result = await client.run(['remote', 'get-url', 'origin']);
+  if (!result || result.code !== 0) {
+    throw new Error(
+      result?.stderr.trim() || 'Failed to get remote URL. Provide repository URL or run inside a git repo.'
+    );
+  }
+  return result.stdout.trim();
+}


### PR DESCRIPTION
## Summary
- move repository URL resolver into git-lib
- reuse git-lib in CLI to resolve remote when URL omitted
- document git-lib resolver for automatic remote fallback

## Testing
- `pnpm lint` *(fails: Unexpected any in packages/core/src/container/index.ts)*
- `pnpm --filter @gitany/cli lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c52f42754c8326a7d4a7cc847c4efe