### PR TITLE
feat(cli): unify GitcodeClient usage with helper

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -442,3 +442,16 @@ gitcode user namespace
 ## 本地存储路径
 
 CLI 将认证信息保存到：`~/.gitany/gitcode/config.json`
+
+## 开发辅助
+
+在编写自定义命令时，可使用 `withClient` 工具统一创建 `GitcodeClient` 并处理错误：
+
+```ts
+import { withClient } from '@gitany/cli/utils/with-client';
+
+await withClient(async (client) => {
+  const user = await client.user.getProfile();
+  console.log(user.login);
+});
+```

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,8 +1,5 @@
 import { Command } from 'commander';
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../utils/with-client';
 
 export function authCommand(): Command {
   const authProgram = new Command('auth').description('Authentication commands');
@@ -12,14 +9,13 @@ export function authCommand(): Command {
     .description('Set authentication token')
     .argument('<token>', 'Authentication token')
     .action(async (token) => {
-      try {
-        const client = new GitcodeClient();
-        await client.auth.setToken(token.trim());
-        console.log('Token saved successfully');
-      } catch (error) {
-        logger.error({ error }, 'Failed to save token');
-        process.exit(1);
-      }
+      await withClient(
+        async (client) => {
+          await client.auth.setToken(token.trim());
+          console.log('Token saved successfully');
+        },
+        'Failed to save token',
+      );
     });
 
   return authProgram;

--- a/packages/cli/src/commands/issue/list.ts
+++ b/packages/cli/src/commands/issue/list.ts
@@ -1,44 +1,44 @@
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
 import { resolveRepoUrl } from '@gitany/git-lib';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../../utils/with-client';
 
 export async function listCommand(
   url?: string,
   options: Record<string, string | undefined> = {},
 ): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const repoUrl = await resolveRepoUrl(url);
-    const issues = await client.issue.list(repoUrl, {
-      state: options.state as 'open' | 'closed' | 'all' | undefined,
-      labels: options.labels,
-      page: options.page ? Number(options.page) : undefined,
-      per_page: options.perPage ? Number(options.perPage) : undefined,
-    });
+  await withClient(
+    async (client) => {
+      try {
+        const repoUrl = await resolveRepoUrl(url);
+        const issues = await client.issue.list(repoUrl, {
+          state: options.state as 'open' | 'closed' | 'all' | undefined,
+          labels: options.labels,
+          page: options.page ? Number(options.page) : undefined,
+          per_page: options.perPage ? Number(options.perPage) : undefined,
+        });
 
-    if (options.json) {
-      console.log(JSON.stringify(issues, null, 2));
-      return;
-    }
+        if (options.json) {
+          console.log(JSON.stringify(issues, null, 2));
+          return;
+        }
 
-    for (const issue of issues as unknown[]) {
-      const item = issue as Record<string, unknown>;
-      const num = (item.number ?? item.iid ?? item.id) as number | string | undefined;
-      const title = (item.title ?? item.subject ?? item.name ?? '(no title)') as string;
-      const numStr = typeof num === 'number' ? num : (num ?? '?');
-      console.log(`- [#${numStr}] ${title}`);
-    }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/\b404\b/.test(msg)) {
-      if (options.json) {
-        console.log('[]');
+        for (const issue of issues as unknown[]) {
+          const item = issue as Record<string, unknown>;
+          const num = (item.number ?? item.iid ?? item.id) as number | string | undefined;
+          const title = (item.title ?? item.subject ?? item.name ?? '(no title)') as string;
+          const numStr = typeof num === 'number' ? num : (num ?? '?');
+          console.log(`- [#${numStr}] ${title}`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/\b404\b/.test(msg)) {
+          if (options.json) {
+            console.log('[]');
+          }
+          return;
+        }
+        throw err;
       }
-      return;
-    }
-    logger.error({ err }, 'Failed to list issues');
-    process.exit(1);
-  }
+    },
+    'Failed to list issues',
+  );
 }

--- a/packages/cli/src/commands/issue/status.ts
+++ b/packages/cli/src/commands/issue/status.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
-import { GitcodeClient, parseGitUrl } from '@gitany/gitcode';
+import { parseGitUrl } from '@gitany/gitcode';
 import { resolveRepoUrl } from '@gitany/git-lib';
-import { createLogger } from '@gitany/shared';
+import { withClient } from '../../utils/with-client';
 
 interface StatusOptions {
   json?: boolean;
@@ -9,9 +9,7 @@ interface StatusOptions {
 }
 
 export async function statusAction(urlArg?: string, options: StatusOptions = {}) {
-  const logger = createLogger('@gitany/cli');
-  try {
-    const client = new GitcodeClient();
+  await withClient(async (client) => {
 
     // 解析 repository URL
     let owner: string;
@@ -111,11 +109,7 @@ export async function statusAction(urlArg?: string, options: StatusOptions = {})
       console.log(`   • List all issues:   gitcode issue list ${owner}/${repo}`);
       console.log(`   • View repository:   ${colors.blue}https://gitcode.com/${owner}/${repo}${colors.reset}`);
     }
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    logger.error({ err: error }, '\n❌ Failed to get issue status: %s', msg);
-    process.exit(1);
-  }
+  }, 'Failed to get issue status');
 }
 
 export function statusCommand(): Command {

--- a/packages/cli/src/commands/pr/comments.ts
+++ b/packages/cli/src/commands/pr/comments.ts
@@ -1,7 +1,7 @@
-import { GitcodeClient } from '@gitany/gitcode';
 import type { PRCommentQueryOptions } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
 import { resolveRepoUrl } from '@gitany/git-lib';
+import { withClient } from '../../utils/with-client';
 
 const logger = createLogger('@gitany/cli');
 
@@ -23,41 +23,44 @@ export async function prCommentsCommand(
     return;
   }
 
-  try {
-    const client = new GitcodeClient();
-    const repoUrl = await resolveRepoUrl(url);
-    const comments = await client.pr.comments(repoUrl, n, {
-      page: options.page ? Number(options.page) : undefined,
-      per_page: options.perPage ? Number(options.perPage) : undefined,
-      comment_type: isPrCommentType(options.commentType)
-        ? options.commentType
-        : undefined,
-    });
+  await withClient(
+    async (client) => {
+      try {
+        const repoUrl = await resolveRepoUrl(url);
+        const comments = await client.pr.comments(repoUrl, n, {
+          page: options.page ? Number(options.page) : undefined,
+          per_page: options.perPage ? Number(options.perPage) : undefined,
+          comment_type: isPrCommentType(options.commentType)
+            ? options.commentType
+            : undefined,
+        });
 
-    if (options.json) {
-      console.log(JSON.stringify(comments, null, 2));
-      return;
-    }
+        if (options.json) {
+          console.log(JSON.stringify(comments, null, 2));
+          return;
+        }
 
-    for (const comment of comments as unknown[]) {
-      const item = comment as Record<string, unknown>;
-      const id = (item.id ?? item.comment_id ?? '?') as number | string;
-      const body = (item.body ?? '').toString().split('\n')[0];
-      const createdAt = (item.created_at ?? '') as string;
-      const author = (item.user as Record<string, unknown>)?.login ?? '?';
+        for (const comment of comments as unknown[]) {
+          const item = comment as Record<string, unknown>;
+          const id = (item.id ?? item.comment_id ?? '?') as number | string;
+          const body = (item.body ?? '').toString().split('\n')[0];
+          const createdAt = (item.created_at ?? '') as string;
+          const author = (item.user as Record<string, unknown>)?.login ?? '?';
 
-      const dateStr = createdAt ? new Date(createdAt).toLocaleDateString() : '';
-      console.log(`- [#${id}] ${author} on ${dateStr}: ${body}`);
-    }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/\b404\b/.test(msg)) {
-      if (options.json) {
-        console.log('[]');
+          const dateStr = createdAt ? new Date(createdAt).toLocaleDateString() : '';
+          console.log(`- [#${id}] ${author} on ${dateStr}: ${body}`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/\b404\b/.test(msg)) {
+          if (options.json) {
+            console.log('[]');
+          }
+          return;
+        }
+        throw err;
       }
-      return;
-    }
-    logger.error({ err }, 'Failed to list PR comments');
-    process.exit(1);
-  }
+    },
+    'Failed to list PR comments',
+  );
 }

--- a/packages/cli/src/commands/pr/create.ts
+++ b/packages/cli/src/commands/pr/create.ts
@@ -1,6 +1,7 @@
-import { GitcodeClient, type CreatePullBody } from '@gitany/gitcode';
+import { type CreatePullBody } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
 import { resolveRepoUrl } from '@gitany/git-lib';
+import { withClient } from '../../utils/with-client';
 
 const logger = createLogger('@gitany/cli');
 
@@ -8,40 +9,39 @@ export async function createCommand(
   url?: string,
   options: Record<string, string | undefined> = {},
 ): Promise<void> {
-  try {
-    const body: CreatePullBody = {
-      title: options.title,
-      head: options.head,
-    };
+  const body: CreatePullBody = {
+    title: options.title,
+    head: options.head,
+  };
 
-    if (options.base) body.base = options.base;
-    if (options.body) body.body = options.body;
-    if (options.issue) {
-      const n = Number(options.issue);
-      if (!Number.isFinite(n) || n <= 0) {
-        logger.error('Invalid --issue number');
-        process.exit(1);
-        return;
-      }
-      body.issue = n;
-    }
-
-    const client = new GitcodeClient();
-    const repoUrl = await resolveRepoUrl(url);
-    const created = await client.pr.create(repoUrl, body);
-
-    if (options.json) {
-      console.log(JSON.stringify(created, null, 2));
+  if (options.base) body.base = options.base;
+  if (options.body) body.body = options.body;
+  if (options.issue) {
+    const n = Number(options.issue);
+    if (!Number.isFinite(n) || n <= 0) {
+      logger.error('Invalid --issue number');
+      process.exit(1);
       return;
     }
-
-    const pr = created as Record<string, unknown>;
-    const num = (pr.number ?? pr.iid ?? pr.id) as number | string | undefined;
-    const titleOut = (pr.title ?? '(no title)') as string;
-    const numStr = typeof num === 'number' ? num : (num ?? '?');
-    console.log(`Created PR #${numStr}: ${titleOut}`);
-  } catch (err) {
-    logger.error({ err }, 'Failed to create PR');
-    process.exit(1);
+    body.issue = n;
   }
+
+  await withClient(
+    async (client) => {
+      const repoUrl = await resolveRepoUrl(url);
+      const created = await client.pr.create(repoUrl, body);
+
+      if (options.json) {
+        console.log(JSON.stringify(created, null, 2));
+        return;
+      }
+
+      const pr = created as Record<string, unknown>;
+      const num = (pr.number ?? pr.iid ?? pr.id) as number | string | undefined;
+      const titleOut = (pr.title ?? '(no title)') as string;
+      const numStr = typeof num === 'number' ? num : (num ?? '?');
+      console.log(`Created PR #${numStr}: ${titleOut}`);
+    },
+    'Failed to create PR',
+  );
 }

--- a/packages/cli/src/commands/pr/list.ts
+++ b/packages/cli/src/commands/pr/list.ts
@@ -1,46 +1,46 @@
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
 import { resolveRepoUrl } from '@gitany/git-lib';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../../utils/with-client';
 
 export async function listCommand(
   url?: string,
   options: Record<string, string | undefined> = {},
 ): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const repoUrl = await resolveRepoUrl(url);
-    const pulls = await client.pr.list(repoUrl, {
-      state: options.state,
-      head: options.head,
-      base: options.base,
-      sort: options.sort,
-      direction: options.direction,
-    });
+  await withClient(
+    async (client) => {
+      try {
+        const repoUrl = await resolveRepoUrl(url);
+        const pulls = await client.pr.list(repoUrl, {
+          state: options.state,
+          head: options.head,
+          base: options.base,
+          sort: options.sort,
+          direction: options.direction,
+        });
 
-    if (options.json) {
-      console.log(JSON.stringify(pulls, null, 2));
-      return;
-    }
+        if (options.json) {
+          console.log(JSON.stringify(pulls, null, 2));
+          return;
+        }
 
-    // Default: print bullet list of titles: - [#<number>] <title>
-    for (const pr of pulls as unknown[]) {
-      const item = pr as Record<string, unknown>;
-      const num = (item.number ?? item.iid ?? item.id) as number | string | undefined;
-      const title = (item.title ?? item.subject ?? item.name ?? '(no title)') as string;
-      const numStr = typeof num === 'number' ? num : (num ?? '?');
-      console.log(`- [#${numStr}] ${title}`);
-    }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/\b404\b/.test(msg)) {
-      if (options.json) {
-        console.log('[]');
+        // Default: print bullet list of titles: - [#<number>] <title>
+        for (const pr of pulls as unknown[]) {
+          const item = pr as Record<string, unknown>;
+          const num = (item.number ?? item.iid ?? item.id) as number | string | undefined;
+          const title = (item.title ?? item.subject ?? item.name ?? '(no title)') as string;
+          const numStr = typeof num === 'number' ? num : (num ?? '?');
+          console.log(`- [#${numStr}] ${title}`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/\b404\b/.test(msg)) {
+          if (options.json) {
+            console.log('[]');
+          }
+          return;
+        }
+        throw err;
       }
-      return;
-    }
-    logger.error({ err }, 'Failed to list PRs');
-    process.exit(1);
-  }
+    },
+    'Failed to list PRs',
+  );
 }

--- a/packages/cli/src/commands/pr/settings.ts
+++ b/packages/cli/src/commands/pr/settings.ts
@@ -1,25 +1,21 @@
 import { Command } from 'commander';
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../../utils/with-client';
 
 export async function prSettingsCommand(owner: string, repo: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const settings = await client.pr.getSettings(owner, repo);
+  await withClient(
+    async (client) => {
+      const settings = await client.pr.getSettings(owner, repo);
 
-    console.log('PR 设置:');
-    console.log(`  允许合并提交: ${settings.allow_merge_commits ? '是' : '否'}`);
-    console.log(`  允许压缩提交: ${settings.allow_squash_commits ? '是' : '否'}`);
-    console.log(`  允许变基提交: ${settings.allow_rebase_commits ? '是' : '否'}`);
-    console.log(`  允许从默认分支更新: ${settings.allow_updates_from_default_branch ? '是' : '否'}`);
-    console.log(`  允许工作树继承: ${settings.allow_worktree_inheritance ? '是' : '否'}`);
-    console.log(`  冲突时自动关闭: ${settings.allow_auto_close_on_conflict ? '是' : '否'}`);
-  } catch (error) {
-    logger.error({ error }, '获取 PR 设置失败');
-    process.exit(1);
-  }
+      console.log('PR 设置:');
+      console.log(`  允许合并提交: ${settings.allow_merge_commits ? '是' : '否'}`);
+      console.log(`  允许压缩提交: ${settings.allow_squash_commits ? '是' : '否'}`);
+      console.log(`  允许变基提交: ${settings.allow_rebase_commits ? '是' : '否'}`);
+      console.log(`  允许从默认分支更新: ${settings.allow_updates_from_default_branch ? '是' : '否'}`);
+      console.log(`  允许工作树继承: ${settings.allow_worktree_inheritance ? '是' : '否'}`);
+      console.log(`  冲突时自动关闭: ${settings.allow_auto_close_on_conflict ? '是' : '否'}`);
+    },
+    '获取 PR 设置失败',
+  );
 }
 
 export function prSubCommand(): Command {

--- a/packages/cli/src/commands/repo/info.ts
+++ b/packages/cli/src/commands/repo/info.ts
@@ -1,89 +1,81 @@
 import { Command } from 'commander';
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../../utils/with-client';
 
 export async function repoSettingsCommand(owner: string, repo: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const settings = await client.repo.getSettings(owner, repo);
+  await withClient(
+    async (client) => {
+      const settings = await client.repo.getSettings(owner, repo);
 
-    console.log('仓库设置:');
-    console.log(JSON.stringify(settings, null, 2));
-  } catch (error) {
-    logger.error({ error }, '获取仓库设置失败');
-    process.exit(1);
-  }
+      console.log('仓库设置:');
+      console.log(JSON.stringify(settings, null, 2));
+    },
+    '获取仓库设置失败',
+  );
 }
 
 export async function repoBranchesCommand(owner: string, repo: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const branches = await client.repo.getBranches(owner, repo);
+  await withClient(
+    async (client) => {
+      const branches = await client.repo.getBranches(owner, repo);
 
-    console.log('仓库分支:');
-    branches.forEach(branch => {
-      console.log(`  ${branch.name} (默认: ${branch.default ? '是' : '否'}, 受保护: ${branch.protected ? '是' : '否'})`);
-    });
-  } catch (error) {
-    logger.error({ error }, '获取仓库分支失败');
-    process.exit(1);
-  }
+      console.log('仓库分支:');
+      branches.forEach(branch => {
+        console.log(`  ${branch.name} (默认: ${branch.default ? '是' : '否'}, 受保护: ${branch.protected ? '是' : '否'})`);
+      });
+    },
+    '获取仓库分支失败',
+  );
 }
 
 export async function repoCommitsCommand(owner: string, repo: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const commits = await client.repo.getCommits(owner, repo);
+  await withClient(
+    async (client) => {
+      const commits = await client.repo.getCommits(owner, repo);
 
-    console.log('仓库提交历史:');
-    commits.forEach((commit, index) => {
-      console.log(`  ${index + 1}. ${commit.sha.substring(0, 7)} - ${commit.commit.message.trim()}`);
-      console.log(`     作者: ${commit.commit.author.name} <${commit.commit.author.email}>`);
-      console.log(`     时间: ${commit.commit.author.date}`);
-      console.log();
-    });
-  } catch (error) {
-    logger.error({ error }, '获取仓库提交历史失败');
-    process.exit(1);
-  }
+      console.log('仓库提交历史:');
+      commits.forEach((commit, index) => {
+        console.log(`  ${index + 1}. ${commit.sha.substring(0, 7)} - ${commit.commit.message.trim()}`);
+        console.log(`     作者: ${commit.commit.author.name} <${commit.commit.author.email}>`);
+        console.log(`     时间: ${commit.commit.author.date}`);
+        console.log();
+      });
+    },
+    '获取仓库提交历史失败',
+  );
 }
 
 export async function repoContributorsCommand(owner: string, repo: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const contributors = await client.repo.getContributors(owner, repo);
+  await withClient(
+    async (client) => {
+      const contributors = await client.repo.getContributors(owner, repo);
 
-    console.log('仓库贡献者:');
-    contributors.forEach(contributor => {
-      console.log(`  ${contributor.name} <${contributor.email}> - ${contributor.contributions} 次贡献`);
-    });
-  } catch (error) {
-    logger.error({ error }, '获取仓库贡献者失败');
-    process.exit(1);
-  }
+      console.log('仓库贡献者:');
+      contributors.forEach(contributor => {
+        console.log(`  ${contributor.name} <${contributor.email}> - ${contributor.contributions} 次贡献`);
+      });
+    },
+    '获取仓库贡献者失败',
+  );
 }
 
 export async function repoWebhooksCommand(owner: string, repo: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const webhooks = await client.repo.getWebhooks(owner, repo);
+  await withClient(
+    async (client) => {
+      const webhooks = await client.repo.getWebhooks(owner, repo);
 
-    console.log('仓库 Webhooks:');
-    webhooks.forEach(webhook => {
-      console.log(`  ID: ${webhook.id}`);
-      console.log(`  URL: ${webhook.url}`);
-      console.log(`  名称: ${webhook.name}`);
-      console.log(`  活跃: ${webhook.active ? '是' : '否'}`);
-      console.log(`  事件: ${webhook.events.join(', ')}`);
-      console.log(`  创建时间: ${webhook.created_at}`);
-      console.log();
-    });
-  } catch (error) {
-    logger.error({ error }, '获取仓库 Webhooks 失败');
-    process.exit(1);
-  }
+      console.log('仓库 Webhooks:');
+      webhooks.forEach(webhook => {
+        console.log(`  ID: ${webhook.id}`);
+        console.log(`  URL: ${webhook.url}`);
+        console.log(`  名称: ${webhook.name}`);
+        console.log(`  活跃: ${webhook.active ? '是' : '否'}`);
+        console.log(`  事件: ${webhook.events.join(', ')}`);
+        console.log(`  创建时间: ${webhook.created_at}`);
+        console.log();
+      });
+    },
+    '获取仓库 Webhooks 失败',
+  );
 }
 
 export function repoSubCommand(): Command {

--- a/packages/cli/src/commands/repo/permission.ts
+++ b/packages/cli/src/commands/repo/permission.ts
@@ -1,17 +1,13 @@
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
 import { resolveRepoUrl } from '@gitany/git-lib';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../../utils/with-client';
 
 export async function permissionCommand(url?: string): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const repoUrl = await resolveRepoUrl(url);
-    const permission = await client.repo.getSelfRepoPermissionRole(repoUrl);
-    console.log(permission);
-  } catch (err) {
-    logger.error({ err }, 'Failed to get repo permission');
-    process.exit(1);
-  }
+  await withClient(
+    async (client) => {
+      const repoUrl = await resolveRepoUrl(url);
+      const permission = await client.repo.getSelfRepoPermissionRole(repoUrl);
+      console.log(permission);
+    },
+    'Failed to get repo permission',
+  );
 }

--- a/packages/cli/src/commands/user/index.ts
+++ b/packages/cli/src/commands/user/index.ts
@@ -1,44 +1,39 @@
 import { Command } from 'commander';
-import { GitcodeClient } from '@gitany/gitcode';
-import { createLogger } from '@gitany/shared';
-
-const logger = createLogger('@gitany/cli');
+import { withClient } from '../../utils/with-client';
 
 export async function userShowCommand(): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const user = await client.user.getProfile();
+  await withClient(
+    async (client) => {
+      const user = await client.user.getProfile();
 
-    console.log('用户信息:');
-    console.log(`  ID: ${user.id}`);
-    console.log(`  用户名: ${user.name}`);
-    console.log(`  邮箱: ${user.email}`);
-    console.log(`  个人主页: ${user.html_url}`);
-    console.log(`  简介: ${user.bio || '无'}`);
-    console.log(`  关注者: ${user.followers}`);
-    console.log(`  关注中: ${user.following}`);
-    console.log(`  主要语言: ${user.top_languages.join(', ')}`);
-  } catch (error) {
-    logger.error({ error }, '获取用户信息失败');
-    process.exit(1);
-  }
+      console.log('用户信息:');
+      console.log(`  ID: ${user.id}`);
+      console.log(`  用户名: ${user.name}`);
+      console.log(`  邮箱: ${user.email}`);
+      console.log(`  个人主页: ${user.html_url}`);
+      console.log(`  简介: ${user.bio || '无'}`);
+      console.log(`  关注者: ${user.followers}`);
+      console.log(`  关注中: ${user.following}`);
+      console.log(`  主要语言: ${user.top_languages.join(', ')}`);
+    },
+    '获取用户信息失败',
+  );
 }
 
 export async function userNamespaceCommand(): Promise<void> {
-  try {
-    const client = new GitcodeClient();
-    const namespace = await client.user.getNamespace();
+  await withClient(
+    async (client) => {
+      const namespace = await client.user.getNamespace();
 
-    console.log('用户命名空间:');
-    console.log(`  ID: ${namespace.id}`);
-    console.log(`  路径: ${namespace.path}`);
-    console.log(`  名称: ${namespace.name}`);
-    console.log(`  主页: ${namespace.html_url}`);
-    console.log(`  类型: ${namespace.type}`);
-  } catch (error) {
-    logger.error({ error }, '获取用户命名空间失败');
-    process.exit(1);
-  }
+      console.log('用户命名空间:');
+      console.log(`  ID: ${namespace.id}`);
+      console.log(`  路径: ${namespace.path}`);
+      console.log(`  名称: ${namespace.name}`);
+      console.log(`  主页: ${namespace.html_url}`);
+      console.log(`  类型: ${namespace.type}`);
+    },
+    '获取用户命名空间失败',
+  );
 }
 
 export function userCommand(): Command {

--- a/packages/cli/src/utils/with-client.ts
+++ b/packages/cli/src/utils/with-client.ts
@@ -1,0 +1,17 @@
+import { GitcodeClient } from '@gitany/gitcode';
+import { createLogger } from '@gitany/shared';
+
+const logger = createLogger('@gitany/cli');
+
+export async function withClient(
+  fn: (client: GitcodeClient) => Promise<void>,
+  errorMessage = 'Gitcode client operation failed',
+): Promise<void> {
+  try {
+    const client = new GitcodeClient();
+    await fn(client);
+  } catch (error) {
+    logger.error({ error }, errorMessage);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add `withClient` utility to create `GitcodeClient` with standard error handling
- refactor CLI commands to use helper
- document helper usage for custom commands

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c56e9c4c8326bc864ab06a2aba51