### PR TITLE
refactor(core): modularize container test steps

### DIFF
--- a/packages/core/src/container/collect-diagnostics.ts
+++ b/packages/core/src/container/collect-diagnostics.ts
@@ -1,0 +1,24 @@
+export interface ProjectDiagnostics {
+  packageJsonExists: boolean;
+  pnpmLockExists: boolean;
+  isPnpmProject: boolean;
+}
+
+export class DiagnosticsCollectionError extends Error {}
+
+export function collectDiagnostics(output: string): ProjectDiagnostics {
+  if (!output) {
+    throw new DiagnosticsCollectionError('无输出可供分析');
+  }
+  const packageJsonExists = output.includes('package.json');
+  const pnpmLockExists = output.includes('pnpm-lock.yaml');
+  const isPnpmByPackageManager =
+    output.includes('"packageManager"') && output.includes('pnpm@');
+  const isPnpmByLockFile = pnpmLockExists;
+  return {
+    packageJsonExists,
+    pnpmLockExists,
+    isPnpmProject: isPnpmByPackageManager || isPnpmByLockFile,
+  };
+}
+

--- a/packages/core/src/container/create-workspace-container.ts
+++ b/packages/core/src/container/create-workspace-container.ts
@@ -1,0 +1,36 @@
+import type Docker from 'dockerode';
+import type { Logger } from '@gitany/shared';
+
+export interface CreateWorkspaceContainerOptions {
+  docker: Docker;
+  image: string;
+  env: string[];
+  log: Logger;
+}
+
+export class ContainerCreationError extends Error {}
+
+export async function createWorkspaceContainer({
+  docker,
+  image,
+  env,
+  log,
+}: CreateWorkspaceContainerOptions): Promise<Docker.Container> {
+  try {
+    const container = await docker.createContainer({
+      Image: image,
+      Cmd: ['sh', '-lc', 'tail -f /dev/null'],
+      Env: env,
+      User: 'node',
+      HostConfig: { AutoRemove: false },
+    });
+    await container.start();
+    log.debug(`🐳 容器已创建，ID: ${container.id}`);
+    return container;
+  } catch (error) {
+    throw new ContainerCreationError(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+

--- a/packages/core/src/container/execute-step.ts
+++ b/packages/core/src/container/execute-step.ts
@@ -1,0 +1,72 @@
+import type Docker from 'dockerode';
+import type { Logger } from '@gitany/shared';
+
+export interface ExecuteStepOptions {
+  container: Docker.Container;
+  name: string;
+  script: string;
+  log: Logger;
+  verbose?: boolean;
+}
+
+export interface StepResult {
+  success: boolean;
+  duration: number;
+  output: string;
+}
+
+export class StepExecutionError extends Error {
+  duration: number;
+  constructor(message: string, duration: number) {
+    super(message);
+    this.duration = duration;
+  }
+}
+
+export async function executeStep({
+  container,
+  name,
+  script,
+  log,
+  verbose = false,
+}: ExecuteStepOptions): Promise<StepResult> {
+  const stepStartTime = Date.now();
+  try {
+    const exec = await container.exec({
+      Cmd: ['sh', '-lc', script],
+      AttachStdout: true,
+      AttachStderr: true,
+    });
+
+    const stream = await exec.start({ hijack: true, stdin: false });
+    let stepOutput = '';
+
+    stream.on('data', (data) => {
+      const text = data.toString();
+      stepOutput += text;
+      if (verbose) {
+        try {
+          log.debug(`[${name}] ${text}`);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    return await new Promise<StepResult>((resolve) => {
+      stream.on('end', async () => {
+        const info = await exec.inspect();
+        const duration = Date.now() - stepStartTime;
+        const success = info.ExitCode === 0;
+        resolve({ success, duration, output: stepOutput });
+      });
+    });
+  } catch (error) {
+    const duration = Date.now() - stepStartTime;
+    throw new StepExecutionError(
+      `步骤 ${name} 执行异常: ${error instanceof Error ? error.message : String(error)}`,
+      duration,
+    );
+  }
+}
+

--- a/packages/core/src/container/index.ts
+++ b/packages/core/src/container/index.ts
@@ -3,6 +3,20 @@ export { resetContainer } from './reset-container';
 export { removeContainer } from './remove-container';
 export { getContainer, getContainerStatus } from './get';
 export { testShaBuild } from './test-sha-build';
+export {
+  prepareImage,
+  DockerUnavailableError,
+  ImagePullError,
+} from './prepare-image';
+export {
+  createWorkspaceContainer,
+  ContainerCreationError,
+} from './create-workspace-container';
+export { executeStep, StepExecutionError } from './execute-step';
+export {
+  collectDiagnostics,
+  DiagnosticsCollectionError,
+} from './collect-diagnostics';
 export type {
   ContainerOptions,
   TestShaBuildOptions,

--- a/packages/core/src/container/prepare-image.ts
+++ b/packages/core/src/container/prepare-image.ts
@@ -1,0 +1,54 @@
+import type Docker from 'dockerode';
+import type { Logger } from '@gitany/shared';
+import { ensureDocker } from './shared';
+
+export interface PrepareImageOptions {
+  docker: Docker;
+  image: string;
+  verbose?: boolean;
+  log: Logger;
+}
+
+export type ImagePullStatus = 'exists' | 'pulled';
+
+export class DockerUnavailableError extends Error {}
+export class ImagePullError extends Error {}
+
+export async function prepareImage({
+  docker,
+  image,
+  verbose = false,
+  log,
+}: PrepareImageOptions): Promise<ImagePullStatus> {
+  try {
+    await ensureDocker();
+  } catch {
+    throw new DockerUnavailableError('Docker daemon is not available');
+  }
+
+  try {
+    await docker.getImage(image).inspect();
+    log.debug(`🐳 镜像 ${image} 已存在`);
+    return 'exists';
+  } catch {
+    log.debug(`🐳 拉取镜像 ${image}...`);
+    return await new Promise<ImagePullStatus>((resolve, reject) => {
+      docker.pull(image, (err: unknown, stream: NodeJS.ReadableStream | undefined) => {
+        if (err) return reject(new ImagePullError(String(err)));
+        if (!stream) return reject(new ImagePullError('Docker pull stream is undefined'));
+        if (verbose) {
+          stream.on('data', (d: Buffer) => {
+            try {
+              log.debug(d.toString());
+            } catch {
+              /* ignore */
+            }
+          });
+        }
+        stream.on('end', () => resolve('pulled'));
+        stream.on('error', (e: unknown) => reject(new ImagePullError(String(e))));
+      });
+    });
+  }
+}
+

--- a/packages/core/src/container/test-sha-build.ts
+++ b/packages/core/src/container/test-sha-build.ts
@@ -1,11 +1,32 @@
 import type Docker from 'dockerode';
 
-import { docker, ensureDocker, logger } from './shared';
+import { docker, logger } from './shared';
+import {
+  prepareImage,
+  DockerUnavailableError,
+  ImagePullError,
+  type ImagePullStatus,
+} from './prepare-image';
+import {
+  createWorkspaceContainer,
+} from './create-workspace-container';
+import {
+  executeStep,
+} from './execute-step';
+import {
+  collectDiagnostics,
+  DiagnosticsCollectionError,
+} from './collect-diagnostics';
 import type { TestShaBuildOptions, TestShaBuildResult } from './types';
 
 /**
- * Test whether a repository at a specific commit can install dependencies
- * successfully using pnpm.
+ * Run a sequence of build verification steps inside a disposable container.
+ *
+ * Step order:
+ * 1. `prepareImage` – ensure Docker is available and the Node image exists.
+ * 2. `createWorkspaceContainer` – create a clean workspace container for the repo.
+ * 3. `executeStep` – run clone/verify/checkout/project check/install scripts.
+ * 4. `collectDiagnostics` – parse project files to determine pnpm usage.
  */
 export async function testShaBuild(
   repoUrl: string,
@@ -16,13 +37,15 @@ export async function testShaBuild(
   const verbose = options.verbose ?? false;
   const keepContainer = options.keepContainer ?? false;
   const nodeVersion = options.nodeVersion ?? '18';
-  // Use a child logger for this run; force debug when verbose
   const log = logger.child({ scope: 'core:container', func: 'testShaBuild', sha });
   if (verbose) {
-    try { log.level = 'debug'; } catch { /* ignore */ }
+    try {
+      log.level = 'debug';
+    } catch {
+      /* ignore */
+    }
   }
 
-  // 初始化结果对象
   const result: TestShaBuildResult = {
     success: false,
     exitCode: -1,
@@ -45,234 +68,174 @@ export async function testShaBuild(
     },
   };
 
+  const env = [`REPO_URL=${repoUrl}`, `TARGET_SHA=${sha}`];
+  const imageName = `node:${nodeVersion}`;
+  let container: Docker.Container | undefined;
+  let fullOutput = '';
+
   try {
-    // 检查 Docker 可用性
-    await ensureDocker();
+    const imageStatus: ImagePullStatus = await prepareImage({
+      docker,
+      image: imageName,
+      verbose,
+      log,
+    });
     result.diagnostics.dockerAvailable = true;
+    result.diagnostics.imagePullStatus = imageStatus;
 
-    log.debug(`🐳 Docker 可用，使用 Node.js ${nodeVersion}`);
+    container = await createWorkspaceContainer({
+      docker,
+      image: imageName,
+      env,
+      log,
+    });
+    result.diagnostics.containerId = container.id;
 
-    // 创建单一容器执行所有步骤
-    const env = [`REPO_URL=${repoUrl}`, `TARGET_SHA=${sha}`];
-    let container: Docker.Container | undefined;
-    let fullOutput = '';
+    const cloneResult = await executeStep({
+      container,
+      name: 'clone',
+      script: 'rm -rf /tmp/workspace && git clone "$REPO_URL" /tmp/workspace 2>&1',
+      log,
+      verbose,
+    });
+    fullOutput += cloneResult.output;
+    result.diagnostics.steps.clone = {
+      success: cloneResult.success,
+      duration: cloneResult.duration,
+      error: cloneResult.success ? undefined : cloneResult.output,
+    };
+    result.diagnostics.repoAccessible = cloneResult.success;
+    if (!cloneResult.success) {
+      result.error = `步骤 clone 失败: ${cloneResult.output.trim()}`;
+      return result;
+    }
 
-    try {
-      // 使用官方 Node 镜像，不再构建自定义镜像
-      const imageName = `node:${nodeVersion}`;
-      log.debug(`🐳 使用镜像: ${imageName}`);
-
-      // 若本地不存在镜像则拉取
-      try {
-        await docker.getImage(imageName).inspect();
-        result.diagnostics.imagePullStatus = 'exists';
-        log.debug(`🐳 镜像 ${imageName} 已存在`);
-      } catch {
-        log.debug(`🐳 拉取镜像 ${imageName}...`);
-        await new Promise<void>((resolve, reject) => {
-          docker.pull(imageName, (err: unknown, stream: NodeJS.ReadableStream | undefined) => {
-            if (err) return reject(err instanceof Error ? err : new Error(String(err)));
-            if (!stream) return reject(new Error('Docker pull stream is undefined'));
-            if (verbose) {
-              stream.on('data', (d: Buffer) => {
-                try { log.debug(d.toString()); } catch { /* ignore */ }
-              });
-            }
-            stream.on('end', () => resolve());
-            stream.on('error', (e: unknown) => reject(e instanceof Error ? e : new Error(String(e))));
-          });
-        });
-        result.diagnostics.imagePullStatus = 'pulled';
-        log.debug(`🐳 镜像 ${imageName} 拉取完成`);
-      }
-
-      container = await docker.createContainer({
-        Image: imageName,
-        Cmd: ['sh', '-lc', 'tail -f /dev/null'],
-        Env: env,
-        User: 'node',
-        HostConfig: { AutoRemove: false },
+    const verifyShaResult = await executeStep({
+      container,
+      name: 'verifySha',
+      script:
+        'cd /tmp/workspace && echo "=== 验证SHA存在性 ===" && echo "目标SHA: $TARGET_SHA" && git cat-file -e "$TARGET_SHA" 2>&1 && echo "SHA验证成功" || echo "SHA不存在"',
+      log,
+      verbose,
+    });
+    fullOutput += verifyShaResult.output;
+    result.diagnostics.steps.verifySha = {
+      success: verifyShaResult.success,
+      duration: verifyShaResult.duration,
+      error: verifyShaResult.success ? undefined : verifyShaResult.output,
+    };
+    if (!verifyShaResult.success) {
+      const checkBranchResult = await executeStep({
+        container,
+        name: 'checkBranch',
+        script:
+          'cd /tmp/workspace && git show-ref --verify --quiet "refs/heads/$TARGET_SHA" 2>&1 && echo "是有效分支" || echo "不是有效分支"',
+        log,
+        verbose,
       });
-
-      result.diagnostics.containerId = container.id;
-      await container.start();
-
-      log.debug(`🐳 容器已创建，ID: ${container.id}`);
-
-      // 定义执行步骤的函数
-      const executeStep = async (name: string, script: string) => {
-        log.debug(`📋 执行步骤: ${name}`);
-
-        const stepStartTime = Date.now();
-
-        try {
-          if (!container) {
-            throw new Error('容器未初始化');
-          }
-          const exec = await container.exec({
-            Cmd: ['sh', '-lc', script],
-            AttachStdout: true,
-            AttachStderr: true,
-          });
-
-          const stream = await exec.start({ hijack: true, stdin: false });
-          let stepOutput = '';
-
-          stream.on('data', (data) => {
-            const text = data.toString();
-            stepOutput += text;
-            fullOutput += text;
-
-            if (verbose) {
-              try { log.debug(`[${name}] ${text}`); } catch { /* ignore */ }
-            }
-          });
-
-          return new Promise<{ success: boolean; duration: number; output: string }>((resolve) => {
-            stream.on('end', async () => {
-              const info = await exec.inspect();
-              const duration = Date.now() - stepStartTime;
-              const success = info.ExitCode === 0;
-              resolve({ success, duration, output: stepOutput });
-            });
-          });
-
-        } catch (error) {
-          const duration = Date.now() - stepStartTime;
-          const errorMsg = `步骤 ${name} 执行异常: ${error instanceof Error ? error.message : String(error)}`;
-          return { success: false, duration, output: errorMsg };
-        }
-      };
-
-      // 步骤1: 克隆仓库
-      const cloneResult = await executeStep('clone', 'rm -rf /tmp/workspace && git clone "$REPO_URL" /tmp/workspace 2>&1');
-      result.diagnostics.steps.clone = {
-        success: cloneResult.success,
-        duration: cloneResult.duration,
-        error: cloneResult.success ? undefined : cloneResult.output,
-      };
-      result.diagnostics.repoAccessible = cloneResult.success;
-
-      if (!cloneResult.success) {
-        result.error = `步骤 clone 失败: ${cloneResult.output.trim()}`;
-        return result;
-      }
-
-      // 步骤2: 验证SHA存在性
-      const verifyShaResult = await executeStep('verifySha', `cd /tmp/workspace && echo "=== 验证SHA存在性 ===" && echo "目标SHA: $TARGET_SHA" && git cat-file -e "$TARGET_SHA" 2>&1 && echo "SHA验证成功" || echo "SHA不存在"`);
-
-      result.diagnostics.steps.verifySha = {
-        success: verifyShaResult.success,
-        duration: verifyShaResult.duration,
-        error: verifyShaResult.success ? undefined : verifyShaResult.output,
-      };
-
-      if (!verifyShaResult.success) {
-        // 检查是否是分支名而不是SHA
-        const checkBranchResult = await executeStep('checkBranch', `cd /tmp/workspace && git show-ref --verify --quiet "refs/heads/$TARGET_SHA" 2>&1 && echo "是有效分支" || echo "不是有效分支"`);
-
-        if (!checkBranchResult.success) {
-          result.error = `SHA/分支验证失败: 提交 '$TARGET_SHA' 不存在`;
-          result.success = false;
-          result.exitCode = 1;
-          return result;
-        }
-        // 如果是分支名，继续执行checkout
-      }
-
-      // 步骤3: 切换到指定SHA
-      const checkoutResult = await executeStep('checkout', 'cd /tmp/workspace && git checkout "$TARGET_SHA" 2>&1');
-      result.diagnostics.steps.checkout = {
-        success: checkoutResult.success,
-        duration: checkoutResult.duration,
-        error: checkoutResult.success ? undefined : checkoutResult.output,
-      };
-
-      if (!checkoutResult.success) {
-        result.error = `步骤 checkout 失败: ${checkoutResult.output.trim()}`;
-        return result;
-      }
-
-      // 步骤4: 检查项目类型和文件存在性
-      const checkProjectResult = await executeStep('checkProject', 'cd /tmp/workspace && echo "=== 检查项目文件 ===" && ls -la package.json 2>/dev/null && ls -la pnpm-lock.yaml 2>/dev/null && echo "=== 检查 package.json ===" && cat package.json | grep -E "packageManager|lockfileVersion" || echo "=== 文件检查完成 ==="');
-
-      // 解析检查结果
-      const output = checkProjectResult.output;
-      result.diagnostics.packageJsonExists = output.includes('package.json');
-      result.diagnostics.pnpmLockExists = output.includes('pnpm-lock.yaml');
-
-      // 判断是否为 pnpm 项目
-      const isPnpmByPackageManager = output.includes('"packageManager"') && output.includes('pnpm@');
-      const isPnpmByLockFile = result.diagnostics.pnpmLockExists;
-      result.diagnostics.isPnpmProject = isPnpmByPackageManager || isPnpmByLockFile;
-
-      result.diagnostics.steps.checkProject = {
-        success: checkProjectResult.success,
-        duration: checkProjectResult.duration,
-        error: checkProjectResult.success ? undefined : '项目检查失败',
-      };
-
-      // 如果不是 pnpm 项目，直接返回失败
-      if (!result.diagnostics.isPnpmProject) {
-        const reason = result.diagnostics.packageJsonExists
-          ? '项目不是 pnpm 项目 (未检测到 packageManager 或 pnpm-lock.yaml)'
-          : '项目缺少 package.json 文件';
-        result.error = `项目检查失败: ${reason}`;
-        result.success = false;
+      fullOutput += checkBranchResult.output;
+      if (!checkBranchResult.success) {
+        result.error = `SHA/分支验证失败: 提交 '$TARGET_SHA' 不存在`;
         result.exitCode = 1;
         return result;
       }
+    }
 
-      // 步骤5: 安装 pnpm（按项目声明版本；否则安装最新版）并执行安装
-      const installResult = await executeStep(
-        'install',
-        `cd /tmp/workspace && PNPM_VER=$(node -e "try{const s=require('./package.json').packageManager||''; if(String(s).includes('pnpm@')){process.stdout.write(String(s).split('pnpm@').pop());}else{process.stdout.write('latest')}}catch(e){process.stdout.write('latest')}") && corepack prepare pnpm@$PNPM_VER --activate && corepack pnpm --version && corepack pnpm install 2>&1`,
-      );
-      result.diagnostics.steps.install = {
-        success: installResult.success,
-        duration: installResult.duration,
-        error: installResult.success ? undefined : installResult.output,
-      };
+    const checkoutResult = await executeStep({
+      container,
+      name: 'checkout',
+      script: 'cd /tmp/workspace && git checkout "$TARGET_SHA" 2>&1',
+      log,
+      verbose,
+    });
+    fullOutput += checkoutResult.output;
+    result.diagnostics.steps.checkout = {
+      success: checkoutResult.success,
+      duration: checkoutResult.duration,
+      error: checkoutResult.success ? undefined : checkoutResult.output,
+    };
+    if (!checkoutResult.success) {
+      result.error = `步骤 checkout 失败: ${checkoutResult.output.trim()}`;
+      return result;
+    }
 
-      if (!installResult.success) {
-        result.error = `步骤 install 失败: ${installResult.output.trim()}`;
+    const checkProjectResult = await executeStep({
+      container,
+      name: 'checkProject',
+      script:
+        'cd /tmp/workspace && echo "=== 检查项目文件 ===" && ls -la package.json 2>/dev/null && ls -la pnpm-lock.yaml 2>/dev/null && echo "=== 检查 package.json ===" && cat package.json | grep -E "packageManager|lockfileVersion" || echo "=== 文件检查完成 ==="',
+      log,
+      verbose,
+    });
+    fullOutput += checkProjectResult.output;
+    result.diagnostics.steps.checkProject = {
+      success: checkProjectResult.success,
+      duration: checkProjectResult.duration,
+      error: checkProjectResult.success ? undefined : '项目检查失败',
+    };
+    try {
+      const diag = collectDiagnostics(checkProjectResult.output);
+      result.diagnostics.packageJsonExists = diag.packageJsonExists;
+      result.diagnostics.pnpmLockExists = diag.pnpmLockExists;
+      result.diagnostics.isPnpmProject = diag.isPnpmProject;
+    } catch (e) {
+      if (e instanceof DiagnosticsCollectionError) {
+        result.error = `项目诊断失败: ${e.message}`;
         return result;
       }
-
-      // 所有步骤成功
-      result.success = true;
-      result.exitCode = 0;
-      result.output = fullOutput;
-      // 保留 imagePullStatus 为 'exists' 或 'pulled'，不覆盖
-
-    } catch (error) {
-      // 如果在拉取镜像阶段失败，标记 pull 失败
-      if (String(error).includes('pull') || String(error).includes('Pull')) {
-        result.diagnostics.imagePullStatus = 'failed';
-      }
-      result.error = `容器执行异常: ${error instanceof Error ? error.message : String(error)}`;
-      result.exitCode = 1;
-    } finally {
-      // 清理容器（如果不需要保留）
-      if (!keepContainer && container) {
-        try {
-          await container.remove({ force: true });
-        } catch {
-          /* ignore */
-        }
-      }
+      throw e;
     }
-  } catch (error) {
-    result.error = error instanceof Error ? error.message : String(error);
-    result.exitCode = 1;
+    if (!result.diagnostics.isPnpmProject) {
+      const reason = result.diagnostics.packageJsonExists
+        ? '项目不是 pnpm 项目 (未检测到 packageManager 或 pnpm-lock.yaml)'
+        : '项目缺少 package.json 文件';
+      result.error = `项目检查失败: ${reason}`;
+      result.exitCode = 1;
+      return result;
+    }
 
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    if (errorMessage.includes('Docker daemon is not available')) {
+    const installResult = await executeStep({
+      container,
+      name: 'install',
+      script:
+        `cd /tmp/workspace && PNPM_VER=$(node -e "try{const s=require('./package.json').packageManager||''; if(String(s).includes('pnpm@')){process.stdout.write(String(s).split('pnpm@').pop());}else{process.stdout.write('latest')}}catch(e){process.stdout.write('latest')}") && corepack prepare pnpm@$PNPM_VER --activate && corepack pnpm --version && corepack pnpm install 2>&1`,
+      log,
+      verbose,
+    });
+    fullOutput += installResult.output;
+    result.diagnostics.steps.install = {
+      success: installResult.success,
+      duration: installResult.duration,
+      error: installResult.success ? undefined : installResult.output,
+    };
+    if (!installResult.success) {
+      result.error = `步骤 install 失败: ${installResult.output.trim()}`;
+      return result;
+    }
+
+    result.success = true;
+    result.exitCode = 0;
+    result.output = fullOutput;
+  } catch (error) {
+    result.exitCode = 1;
+    result.error = error instanceof Error ? error.message : String(error);
+    if (error instanceof DockerUnavailableError) {
       result.diagnostics.dockerAvailable = false;
+    }
+    if (error instanceof ImagePullError) {
+      result.diagnostics.imagePullStatus = 'failed';
     }
   } finally {
     result.duration = Date.now() - startTime;
+    if (!keepContainer && container) {
+      try {
+        await container.remove({ force: true });
+      } catch {
+        /* ignore */
+      }
+    }
   }
 
   return result;
 }
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,4 +11,13 @@ export {
   getContainer,
   getContainerStatus,
   testShaBuild,
+  prepareImage,
+  DockerUnavailableError,
+  ImagePullError,
+  createWorkspaceContainer,
+  ContainerCreationError,
+  executeStep,
+  StepExecutionError,
+  collectDiagnostics,
+  DiagnosticsCollectionError,
 } from './container';


### PR DESCRIPTION
## Summary
- split container build test into prepareImage, createWorkspaceContainer, executeStep and collectDiagnostics modules
- simplify testShaBuild to orchestrate steps and document order
- export step utilities and error types for unit testing

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c57441c883268003939c7ffa184d