### PR TITLE
Improve Git client error message when git binary missing

### DIFF
--- a/packages/git-lib/src/client/index.ts
+++ b/packages/git-lib/src/client/index.ts
@@ -20,7 +20,7 @@ export class GitClient {
       return await runGit(args, { cwd: this.cwd });
     } catch (err) {
       if (err instanceof GitNotFoundError) {
-        throw err;
+        throw new GitNotFoundError('Git command not found. Please install Git and ensure it is in PATH.');
       }
       throw err;
     }


### PR DESCRIPTION
## Summary
- clarify Git command not found by throwing custom GitNotFoundError message

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c7e69a42c483268eca378c55d63039