### PR TITLE
refactor: modularize testShaBuild steps

### DIFF
--- a/packages/core/src/container/check-project-files.ts
+++ b/packages/core/src/container/check-project-files.ts
@@ -1,0 +1,23 @@
+import { executeStep, type ExecuteStepOptions, type StepResult } from './execute-step';
+import { collectDiagnostics, type ProjectDiagnostics } from './collect-diagnostics';
+
+export type StepOptions = Omit<ExecuteStepOptions, 'name' | 'script'>;
+
+export interface ProjectCheckResult {
+  step: StepResult;
+  diagnostics: ProjectDiagnostics;
+}
+
+export async function checkProjectFiles({ container, log, verbose }: StepOptions): Promise<ProjectCheckResult> {
+  const step = await executeStep({
+    container,
+    name: 'checkProject',
+    script:
+      'cd /tmp/workspace && echo "=== 检查项目文件 ===" && ls -la package.json 2>/dev/null && ls -la pnpm-lock.yaml 2>/dev/null && echo "=== 检查 package.json ===" && cat package.json | grep -E "packageManager|lockfileVersion" || echo "=== 文件检查完成 ==="',
+    log,
+    verbose,
+  });
+  const diagnostics = collectDiagnostics(step.output);
+  return { step, diagnostics };
+}
+

--- a/packages/core/src/container/checkout-sha.ts
+++ b/packages/core/src/container/checkout-sha.ts
@@ -1,0 +1,14 @@
+import { executeStep, type ExecuteStepOptions, type StepResult } from './execute-step';
+
+export type StepOptions = Omit<ExecuteStepOptions, 'name' | 'script'>;
+
+export async function checkoutSha({ container, log, verbose }: StepOptions): Promise<StepResult> {
+  return executeStep({
+    container,
+    name: 'checkout',
+    script: 'cd /tmp/workspace && git checkout "$TARGET_SHA" 2>&1',
+    log,
+    verbose,
+  });
+}
+

--- a/packages/core/src/container/clone-repo.ts
+++ b/packages/core/src/container/clone-repo.ts
@@ -1,0 +1,14 @@
+import { executeStep, type ExecuteStepOptions, type StepResult } from './execute-step';
+
+export type StepOptions = Omit<ExecuteStepOptions, 'name' | 'script'>;
+
+export async function cloneRepo({ container, log, verbose }: StepOptions): Promise<StepResult> {
+  return executeStep({
+    container,
+    name: 'clone',
+    script: 'rm -rf /tmp/workspace && git clone "$REPO_URL" /tmp/workspace 2>&1',
+    log,
+    verbose,
+  });
+}
+

--- a/packages/core/src/container/index.ts
+++ b/packages/core/src/container/index.ts
@@ -3,6 +3,11 @@ export { resetContainer } from './reset-container';
 export { removeContainer } from './remove-container';
 export { getContainer, getContainerStatus } from './get';
 export { testShaBuild } from './test-sha-build';
+export { cloneRepo } from './clone-repo';
+export { verifySha } from './verify-sha';
+export { checkoutSha } from './checkout-sha';
+export { checkProjectFiles } from './check-project-files';
+export { installDependencies } from './install-dependencies';
 export {
   prepareImage,
   DockerUnavailableError,
@@ -22,3 +27,4 @@ export type {
   TestShaBuildOptions,
   TestShaBuildResult,
 } from './types';
+export type { ProjectCheckResult } from './check-project-files';

--- a/packages/core/src/container/install-dependencies.ts
+++ b/packages/core/src/container/install-dependencies.ts
@@ -1,0 +1,15 @@
+import { executeStep, type ExecuteStepOptions, type StepResult } from './execute-step';
+
+export type StepOptions = Omit<ExecuteStepOptions, 'name' | 'script'>;
+
+export async function installDependencies({ container, log, verbose }: StepOptions): Promise<StepResult> {
+  return executeStep({
+    container,
+    name: 'install',
+    script:
+      `cd /tmp/workspace && PNPM_VER=$(node -e "try{const s=require('./package.json').packageManager||''; if(String(s).includes('pnpm@')){process.stdout.write(String(s).split('pnpm@').pop());}else{process.stdout.write('latest')}}catch(e){process.stdout.write('latest')}") && corepack prepare pnpm@$PNPM_VER --activate && corepack pnpm --version && corepack pnpm install 2>&1`,
+    log,
+    verbose,
+  });
+}
+

--- a/packages/core/src/container/verify-sha.ts
+++ b/packages/core/src/container/verify-sha.ts
@@ -1,0 +1,31 @@
+import { executeStep, type ExecuteStepOptions, type StepResult } from './execute-step';
+
+export type StepOptions = Omit<ExecuteStepOptions, 'name' | 'script'>;
+
+export async function verifySha({ container, log, verbose }: StepOptions): Promise<StepResult> {
+  const verify = await executeStep({
+    container,
+    name: 'verifySha',
+    script:
+      'cd /tmp/workspace && echo "=== 验证SHA存在性 ===" && echo "目标SHA: $TARGET_SHA" && git cat-file -e "$TARGET_SHA" 2>&1 && echo "SHA验证成功" || echo "SHA不存在"',
+    log,
+    verbose,
+  });
+  let output = verify.output;
+  let duration = verify.duration;
+  if (verify.success) {
+    return verify;
+  }
+  const checkBranch = await executeStep({
+    container,
+    name: 'checkBranch',
+    script:
+      'cd /tmp/workspace && git show-ref --verify --quiet "refs/heads/$TARGET_SHA" 2>&1 && echo "是有效分支" || echo "不是有效分支"',
+    log,
+    verbose,
+  });
+  output += checkBranch.output;
+  duration += checkBranch.duration;
+  return { success: checkBranch.success, duration, output };
+}
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,11 @@ export {
   getContainer,
   getContainerStatus,
   testShaBuild,
+  cloneRepo,
+  verifySha,
+  checkoutSha,
+  checkProjectFiles,
+  installDependencies,
   prepareImage,
   DockerUnavailableError,
   ImagePullError,
@@ -21,3 +26,4 @@ export {
   collectDiagnostics,
   DiagnosticsCollectionError,
 } from './container';
+export type { ProjectCheckResult } from './container';


### PR DESCRIPTION
## Summary
- split build verification into `cloneRepo`, `verifySha`, `checkoutSha`, `checkProjectFiles`, and `installDependencies`
- orchestrate those helpers in a streamlined `testShaBuild`
- export the new utilities from container and package indexes

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ebc53bcc8326b77940aba50f9880