### PR TITLE
reuse existing PR containers

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -95,7 +95,7 @@ const [pr] = await client.pr.list('https://gitcode.com/owner/repo.git', {
 
 // 手动创建并执行脚本
 await createPrContainer('https://gitcode.com/owner/repo.git', pr);
-const container = getContainer({ pr: pr.id });
+const container = await getContainer({ pr: pr.id });
 if (container) {
   const exec = await container.exec({
     Cmd: ['sh', '-lc', 'pnpm lint && pnpm build'],

--- a/packages/core/src/container/get.ts
+++ b/packages/core/src/container/get.ts
@@ -2,14 +2,35 @@ import type Docker from 'dockerode';
 
 import { docker, ensureDocker } from './shared';
 
-export function getContainer({ pr }: { pr: number }): Docker.Container {
-  return docker.getContainer(`pr-${pr}`);
+export async function getContainer({
+  pr,
+  repoUrl,
+}: {
+  pr: number;
+  repoUrl?: string;
+}): Promise<Docker.Container | undefined> {
+  await ensureDocker();
+
+  const filters: Record<string, string[]> = { label: [`gitany.prId=${pr}`] };
+  if (repoUrl) filters.label.push(`gitany.repoUrl=${repoUrl}`);
+
+  const list = await docker.listContainers({ all: true, filters });
+  if (list.length) return docker.getContainer(list[0].Id);
+
+  const container = docker.getContainer(`pr-${pr}`);
+  try {
+    await container.inspect();
+    return container;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function getContainerStatus(prId: number) {
-  await ensureDocker();
+  const container = await getContainer({ pr: prId });
+  if (!container) return null;
   try {
-    const info = await getContainer({ pr: prId }).inspect();
+    const info = await container.inspect();
     return info.State?.Status ?? null;
   } catch {
     return null;

--- a/packages/core/src/container/remove-container.ts
+++ b/packages/core/src/container/remove-container.ts
@@ -3,7 +3,8 @@ import { getContainer } from './get';
 
 export async function removeContainer(prId: number) {
   await ensureDocker();
-  const container = getContainer({ pr: prId });
+  const container = await getContainer({ pr: prId });
+  if (!container) return;
   try {
     await container.stop({ t: 0 });
   } catch {


### PR DESCRIPTION
## Summary
- reuse existing PR containers to avoid duplicates
- label containers with PR ID and repo URL
- lookup and remove containers by label or legacy name

## Testing
- `pnpm lint`
- `pnpm build`
- `node scripts/check-docs-updated.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c813021f8083269ca85cdcd136088c