### PR TITLE
cache ETag responses

### DIFF
--- a/docs/gitcode/index.md
+++ b/docs/gitcode/index.md
@@ -150,4 +150,4 @@ parseGitUrl('git@gitcode.com:owner/repo.git');
 
 ### 历史变更
 
-- 内部已统一使用 `utils/http.ts` 的 `httpRequest` 进行网络请求，实现 URL 构建、头部合并、鉴权与错误处理的集中管理；对外 API 与行为不变。
+- 内部已统一使用 `utils/http.ts` 的 `httpRequest` 进行网络请求，实现 URL 构建、头部合并、鉴权与错误处理的集中管理，并通过 ETag 自动缓存未变更的响应；对外 API 与行为不变。

--- a/docs/gitcode/issue.md
+++ b/docs/gitcode/issue.md
@@ -102,5 +102,5 @@ console.log(`评论创建成功，ID: ${comment.id}`);
 
 ## 说明
 
-- 网络请求层统一由内部的 `utils/http.ts` 中的 `httpRequest` 处理，对外行为不变。
+- 网络请求层统一由内部的 `utils/http.ts` 中的 `httpRequest` 处理，并通过 ETag 自动缓存未变更的响应，对外行为不变。
 - 字段与返回值与 GitCode 文档保持一致的最小子集，返回结果会通过 Zod 进行结构校验。

--- a/docs/gitcode/pr.md
+++ b/docs/gitcode/pr.md
@@ -167,7 +167,7 @@ interface CreatedPrComment {
 
 ## 说明
 
-- 网络请求层统一由内部的 `utils/http.ts` 中的 `httpRequest` 处理，对外行为不变。
+- 网络请求层统一由内部的 `utils/http.ts` 中的 `httpRequest` 处理，并通过 ETag 自动缓存未变更的响应，对外行为不变。
 - 字段与返回值与 GitCode 文档保持一致的最小子集，返回结果会通过 Zod 进行结构校验。
 - 2025-09-13 更新：新增 PR 设置和评论功能支持。
 - 2025-09-14 更新：新增 PR 创建评论功能支持。

--- a/packages/gitcode/src/utils/index.ts
+++ b/packages/gitcode/src/utils/index.ts
@@ -48,3 +48,5 @@ export function toQuery<T extends object | undefined | null>(
   }
   return out;
 }
+
+export { isNotModified } from './http';


### PR DESCRIPTION
## Summary
- cache ETag and payload per URL in httpRequest and expose isNotModified helper
- skip processing unchanged PR lists and comments in watcher using ETag-aware requests
- document ETag-based response caching in gitcode docs

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c814530aec8326b563136745806041