### PR TITLE
feat: watch issues and route AI mentions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,15 @@
  */
 
 export { watchPullRequest } from './pr/watcher';
+export { watchIssues } from './issue/watcher';
+export { watchAiMentions, defaultPromptBuilder } from './issue/ai-mentions';
+export type { WatchIssueOptions, WatchIssueHandle } from './issue/watcher';
+export type {
+  WatchAiMentionsOptions,
+  AiMentionWatcherHandle,
+  AiMentionContext,
+  AiMentionSource,
+} from './issue/ai-mentions';
 export {
   createPrContainer,
   resetContainer,

--- a/packages/core/src/issue/ai-mentions.ts
+++ b/packages/core/src/issue/ai-mentions.ts
@@ -1,0 +1,233 @@
+import type {
+  GitcodeClient,
+  Issue,
+  IssueComment,
+  PullRequest,
+  PRComment,
+  ListIssuesQuery,
+  IssueCommentsQuery,
+} from '@gitany/gitcode';
+import { createLogger } from '@gitany/shared';
+import { chat, type ChatOptions, type ChatResult } from '../container';
+import { watchIssues, type WatchIssueHandle } from './watcher';
+import { watchPullRequest, type WatchPullRequestHandle } from '../pr/watcher';
+
+const logger = createLogger('@gitany/core');
+
+export type AiMentionSource = 'issue_comment' | 'pr_review_comment';
+
+export interface AiMentionContext {
+  repoUrl: string;
+  issueNumber: number;
+  issue: Issue;
+  mentionComment: IssueComment | PRComment;
+  commentSource: AiMentionSource;
+  issueComments: IssueComment[];
+  pullRequest?: PullRequest;
+}
+
+export interface WatchAiMentionsOptions {
+  mention?: string;
+  issueIntervalSec?: number;
+  prIntervalSec?: number;
+  issueQuery?: ListIssuesQuery;
+  issueCommentQuery?: IssueCommentsQuery;
+  prCommentType?: 'diff_comment' | 'pr_comment';
+  chatOptions?: ChatOptions;
+  chatExecutor?: (repoUrl: string, prompt: string, options?: ChatOptions) => Promise<ChatResult>;
+  buildPrompt?: (context: AiMentionContext) => string | Promise<string>;
+  onChatResult?: (result: ChatResult, context: AiMentionContext) => void;
+  includeIssueComments?: boolean;
+  includePullRequestComments?: boolean;
+}
+
+export interface AiMentionWatcherHandle {
+  stop(): void;
+}
+
+export function watchAiMentions(
+  client: GitcodeClient,
+  repoUrl: string,
+  options: WatchAiMentionsOptions = {},
+): AiMentionWatcherHandle {
+  const mentionToken = options.mention ?? '@AI';
+  const mentionRegex = createMentionRegex(mentionToken);
+  const chatExecutor = options.chatExecutor ?? chat;
+  const issueHandles: WatchIssueHandle[] = [];
+  const prHandles: WatchPullRequestHandle[] = [];
+
+  const handleMention = async (
+    payload: {
+      source: AiMentionSource;
+      comment: IssueComment | PRComment;
+      issueNumber: number;
+      issueSnapshot?: Issue;
+      pullRequest?: PullRequest;
+    },
+  ) => {
+    const { issueNumber, comment, source } = payload;
+    if (!Number.isFinite(issueNumber)) return;
+
+    logger.info({ issueNumber, commentId: comment.id, source }, '[watchAiMentions] mention detected');
+
+    let issueDetail: Issue | undefined = payload.issueSnapshot;
+    if (!issueDetail) {
+      try {
+        issueDetail = await client.issue.get(repoUrl, issueNumber);
+      } catch (err) {
+        logger.error({ err, issueNumber }, '[watchAiMentions] failed to load issue detail');
+        return;
+      }
+    }
+
+    if (!issueDetail) {
+      logger.error({ issueNumber }, '[watchAiMentions] missing issue detail');
+      return;
+    }
+
+    let issueComments: IssueComment[] = [];
+    try {
+      issueComments = await client.issue.comments(repoUrl, issueNumber, options.issueCommentQuery ?? {});
+    } catch (err) {
+      logger.warn({ err, issueNumber }, '[watchAiMentions] failed to load issue comments');
+    }
+
+    const context: AiMentionContext = {
+      repoUrl,
+      issueNumber,
+      issue: issueDetail,
+      mentionComment: comment,
+      commentSource: source,
+      issueComments,
+      pullRequest: payload.pullRequest,
+    };
+
+    let prompt: string;
+    try {
+      const builder = options.buildPrompt ?? defaultPromptBuilder;
+      prompt = await builder(context);
+    } catch (err) {
+      logger.error({ err, issueNumber }, '[watchAiMentions] failed to build prompt');
+      return;
+    }
+
+    if (!prompt?.trim()) {
+      logger.warn({ issueNumber }, '[watchAiMentions] empty prompt generated, skip chat invocation');
+      return;
+    }
+
+    try {
+      const result = await chatExecutor(repoUrl, prompt, options.chatOptions);
+      options.onChatResult?.(result, context);
+      if (!result.success) {
+        logger.error({ issueNumber, commentId: comment.id, error: result.error }, '[watchAiMentions] chat failed');
+      } else {
+        logger.info({ issueNumber, commentId: comment.id }, '[watchAiMentions] chat completed');
+      }
+    } catch (err) {
+      logger.error({ err, issueNumber, commentId: comment.id }, '[watchAiMentions] chat invocation failed');
+    }
+  };
+
+  if (options.includeIssueComments !== false) {
+    const issueHandle = watchIssues(client, repoUrl, {
+      intervalSec: options.issueIntervalSec,
+      issueQuery: options.issueQuery,
+      commentQuery: options.issueCommentQuery,
+      onComment: (issue, comment) => {
+        if (!mentionRegex.test(comment.body)) return;
+        const issueNumber = Number(issue.number);
+        void handleMention({
+          source: 'issue_comment',
+          comment,
+          issueNumber,
+          issueSnapshot: issue,
+        });
+      },
+    });
+    issueHandles.push(issueHandle);
+  }
+
+  if (options.includePullRequestComments !== false) {
+    const prHandle = watchPullRequest(client, repoUrl, {
+      intervalSec: options.prIntervalSec,
+      commentType: options.prCommentType,
+      onComment: (pr, comment) => {
+        if (!mentionRegex.test(comment.body)) return;
+        void handleMention({
+          source: 'pr_review_comment',
+          comment,
+          issueNumber: pr.number,
+          pullRequest: pr,
+        });
+      },
+    });
+    prHandles.push(prHandle);
+  }
+
+  return {
+    stop() {
+      for (const handle of issueHandles) {
+        try {
+          handle.stop();
+        } catch (err) {
+          logger.error({ err }, '[watchAiMentions] failed to stop issue watcher');
+        }
+      }
+      for (const handle of prHandles) {
+        try {
+          handle.stop();
+        } catch (err) {
+          logger.error({ err }, '[watchAiMentions] failed to stop PR watcher');
+        }
+      }
+    },
+  } satisfies AiMentionWatcherHandle;
+}
+
+function createMentionRegex(mention: string): RegExp {
+  const escaped = escapeRegExp(mention.trim());
+  const source = String.raw`(^|\s)${escaped}(?=\b)`;
+  return new RegExp(source, 'i');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function defaultPromptBuilder(context: AiMentionContext): string {
+  const { issue, issueComments, mentionComment, commentSource, repoUrl } = context;
+  const lines: string[] = [];
+  lines.push('You are an AI assistant helping with GitCode issues and pull requests.');
+  lines.push(`Repository: ${repoUrl}`);
+  lines.push(`Issue #${issue.number}: ${issue.title}`);
+
+  const issueBody = issue.body?.trim();
+  if (issueBody) {
+    lines.push(`Issue description:\n${issueBody}`);
+  } else {
+    lines.push('Issue description: (not provided)');
+  }
+
+  const history = issueComments
+    .filter((c) => c.id !== mentionComment.id)
+    .slice(-5)
+    .map((c) => c.body.trim())
+    .filter(Boolean);
+  if (history.length) {
+    lines.push('Recent comments:');
+    for (const entry of history) {
+      lines.push(entry);
+    }
+  }
+
+  lines.push(
+    commentSource === 'pr_review_comment'
+      ? 'Pull request review comment mentioning @AI:'
+      : 'Issue comment mentioning @AI:',
+  );
+  lines.push(mentionComment.body);
+  lines.push('Provide a helpful answer or recommended next steps for the maintainers.');
+
+  return lines.join('\n\n');
+}

--- a/packages/core/src/issue/watcher.ts
+++ b/packages/core/src/issue/watcher.ts
@@ -1,0 +1,188 @@
+import {
+  GitcodeClient,
+  type Issue,
+  type IssueComment,
+  type ListIssuesQuery,
+  type IssueCommentsQuery,
+  isNotModified,
+} from '@gitany/gitcode';
+import { createLogger } from '@gitany/shared';
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { ensureDir, resolveGitcodeSubdir, sha1Hex } from '../utils';
+
+const logger = createLogger('@gitany/core');
+const DEFAULT_INTERVAL_SEC = 5;
+
+export interface WatchIssueOptions {
+  intervalSec?: number;
+  issueQuery?: ListIssuesQuery;
+  commentQuery?: IssueCommentsQuery;
+  onComment?: (issue: Issue, comment: IssueComment) => void;
+}
+
+export interface WatchIssueHandle {
+  stop(): void;
+}
+
+type WatcherState = {
+  lastCommentIdByIssue: Map<number, number>;
+};
+
+type PersistShape = {
+  lastCommentIdByIssue: Record<string, number>;
+};
+
+function createWatcherState(url: string): WatcherState {
+  const persisted = loadPersistedStateSync(url);
+  if (persisted) return persisted;
+  return { lastCommentIdByIssue: new Map() };
+}
+
+export function watchIssues(
+  client: GitcodeClient,
+  url: string,
+  options: WatchIssueOptions = {},
+): WatchIssueHandle {
+  const state = createWatcherState(url);
+
+  const check = async () => {
+    try {
+      const { data: issues } = await fetchIssues(client, url, options);
+      await detectNewComments(client, url, issues, state, options);
+      await persistState(url, state);
+    } catch (err) {
+      logger.error({ err, url }, '[watchIssues] poll failed');
+    }
+  };
+
+  void check();
+
+  const intervalMs = 1000 * (options.intervalSec ?? DEFAULT_INTERVAL_SEC);
+  const intervalId = setInterval(() => {
+    void check();
+  }, intervalMs);
+
+  return {
+    stop: () => clearInterval(intervalId),
+  } satisfies WatchIssueHandle;
+}
+
+async function fetchIssues(
+  client: GitcodeClient,
+  url: string,
+  options: WatchIssueOptions,
+): Promise<{ data: Issue[] }> {
+  const query = options.issueQuery ?? { state: 'all', page: 1, per_page: 20 };
+  const data = await client.issue.list(url, query);
+  return { data };
+}
+
+async function fetchIssueComments(
+  client: GitcodeClient,
+  url: string,
+  issueNumber: number,
+  options: WatchIssueOptions,
+): Promise<{ data: IssueComment[]; notModified: boolean }> {
+  const query = options.commentQuery;
+  const data = await client.issue.comments(url, issueNumber, query ?? {});
+  return { data, notModified: isNotModified(data) };
+}
+
+async function detectNewComments(
+  client: GitcodeClient,
+  url: string,
+  issues: Issue[],
+  state: WatcherState,
+  options: WatchIssueOptions,
+) {
+  if (!options.onComment) return;
+
+  for (const issue of issues) {
+    const issueNumber = Number(issue.number);
+    if (!Number.isFinite(issueNumber)) continue;
+
+    let result: { data: IssueComment[]; notModified: boolean };
+    try {
+      result = await fetchIssueComments(client, url, issueNumber, options);
+    } catch (err) {
+      logger.error({ err, url, issueNumber }, '[watchIssues] failed to fetch comments');
+      continue;
+    }
+
+    const { data: comments, notModified } = result;
+    if (notModified || comments.length === 0) continue;
+
+    const lastSeen = state.lastCommentIdByIssue.get(issueNumber);
+    if (lastSeen === undefined) {
+      const highestId = comments.reduce((max, comment) => (comment.id > max ? comment.id : max), 0);
+      if (highestId > 0) {
+        state.lastCommentIdByIssue.set(issueNumber, highestId);
+      }
+      continue;
+    }
+
+    let maxId = lastSeen;
+    for (let i = comments.length - 1; i >= 0; i -= 1) {
+      const comment = comments[i];
+      if (comment.id > lastSeen) {
+        options.onComment?.(issue, comment);
+        if (comment.id > maxId) {
+          maxId = comment.id;
+        }
+      }
+    }
+
+    if (maxId !== lastSeen) {
+      state.lastCommentIdByIssue.set(issueNumber, maxId);
+    }
+  }
+}
+
+function getStoreDir() {
+  return path.join(resolveGitcodeSubdir('watchers'), 'issues');
+}
+
+function urlKey(url: string) {
+  return sha1Hex(url);
+}
+
+function getStoreFile(url: string) {
+  return path.join(getStoreDir(), `${urlKey(url)}.json`);
+}
+
+function loadPersistedStateSync(url: string): WatcherState | null {
+  try {
+    const file = getStoreFile(url);
+    if (!fsSync.existsSync(file)) return null;
+    const raw = fsSync.readFileSync(file, 'utf8');
+    if (!raw) return null;
+    const data = JSON.parse(raw) as PersistShape;
+    const lastMap = new Map<number, number>();
+    for (const [key, value] of Object.entries(data.lastCommentIdByIssue ?? {})) {
+      const num = Number(key);
+      if (!Number.isNaN(num)) {
+        lastMap.set(num, value);
+      }
+    }
+    return { lastCommentIdByIssue: lastMap };
+  } catch (err) {
+    logger.error({ url, err }, '[watchIssues] Failed to read persisted state');
+    return null;
+  }
+}
+
+async function persistState(url: string, state: WatcherState) {
+  try {
+    const dir = getStoreDir();
+    await ensureDir(dir);
+    const file = getStoreFile(url);
+    const data: PersistShape = {
+      lastCommentIdByIssue: Object.fromEntries(state.lastCommentIdByIssue),
+    };
+    await fs.writeFile(file, JSON.stringify(data), 'utf8');
+  } catch (err) {
+    logger.error({ err }, '[watchIssues] Failed to persist state');
+  }
+}

--- a/packages/gitcode/src/api/issue/get.ts
+++ b/packages/gitcode/src/api/issue/get.ts
@@ -1,0 +1,16 @@
+/**
+ * Issue - Get
+ * Endpoint: GET /api/v5/repos/{owner}/{repo}/issues/{number}
+ */
+
+import { z } from 'zod';
+import { issueSchema } from './list';
+import { API_BASE } from '../constants';
+
+export const issueDetailSchema = issueSchema;
+
+export type IssueDetail = z.infer<typeof issueDetailSchema>;
+
+export function getIssueUrl(owner: string, repo: string, issueNumber: number): string {
+  return `${API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}`;
+}

--- a/packages/gitcode/src/api/issue/index.ts
+++ b/packages/gitcode/src/api/issue/index.ts
@@ -37,3 +37,5 @@ export {
   createIssueCommentUrl,
   createdIssueCommentSchema,
 } from './create-comment';
+export type { IssueDetail } from './get';
+export { issueDetailSchema, getIssueUrl } from './get';

--- a/packages/gitcode/src/client/issue/get.ts
+++ b/packages/gitcode/src/client/issue/get.ts
@@ -1,0 +1,18 @@
+import { getIssueUrl } from '../../api/issue/get';
+import type { GitcodeClient } from '../core';
+import { parseGitUrl } from '../../utils';
+import { issueDetailSchema } from '../../api/issue/get';
+
+export async function getIssue(
+  client: GitcodeClient,
+  url: string,
+  issueNumber: number,
+) {
+  const parsed = parseGitUrl(url);
+  if (!parsed?.owner || !parsed?.repo) {
+    throw new Error(`Invalid Git URL: ${url}`);
+  }
+  const apiUrl = getIssueUrl(parsed.owner, parsed.repo, issueNumber);
+  const json = await client.request(apiUrl, 'GET');
+  return issueDetailSchema.parse(json);
+}

--- a/packages/gitcode/src/client/issue/index.ts
+++ b/packages/gitcode/src/client/issue/index.ts
@@ -3,6 +3,7 @@ import { listIssues } from './list';
 import { listIssueComments } from './comments';
 import { createIssue } from './create';
 import { createIssueComment } from './create-comment';
+import { getIssue } from './get';
 import type {
   ListIssuesQuery,
   IssueCommentsQuery,
@@ -21,6 +22,10 @@ export class GitcodeClientIssue {
     return listIssueComments(this.client, url, issueNumber, query);
   }
 
+  get(url: string, issueNumber: number) {
+    return getIssue(this.client, url, issueNumber);
+  }
+
   create(params: CreateIssueParams) {
     return createIssue(this.client, params);
   }
@@ -30,4 +35,4 @@ export class GitcodeClientIssue {
   }
 }
 
-export { listIssues, listIssueComments, createIssue, createIssueComment };
+export { listIssues, listIssueComments, createIssue, createIssueComment, getIssue };

--- a/packages/gitcode/src/index.ts
+++ b/packages/gitcode/src/index.ts
@@ -46,6 +46,7 @@ export type {
   CreateIssueCommentBody,
   CreateIssueCommentParams,
   CreatedIssueComment,
+  IssueDetail,
 } from './api/issue';
 export {
   listIssuesUrl,
@@ -58,6 +59,8 @@ export {
   createdIssueSchema,
   createIssueCommentUrl,
   createdIssueCommentSchema,
+  issueDetailSchema,
+  getIssueUrl,
 } from './api/issue';
 export {
   userProfileSchema,

--- a/scripts/tests/test-ai-mentions.mjs
+++ b/scripts/tests/test-ai-mentions.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+import { config } from 'dotenv';
+import { watchAiMentions, defaultPromptBuilder } from '../../packages/core/dist/index.js';
+import { GitcodeClient } from '../../packages/gitcode/dist/index.js';
+
+config({ path: new URL('.env', import.meta.url) });
+
+const DEFAULT_MENTION = '@AI';
+
+function usage() {
+  console.log(`
+用法: node test-ai-mentions.mjs [选项]
+
+选项:
+  --repo-url <url>          仓库 URL (默认: ${process.env.TEST_REPO_URL || '无'})
+  --mention <text>          触发标记 (默认: ${process.env.TEST_MENTION || DEFAULT_MENTION})
+  --issue-interval <sec>    Issue 轮询间隔秒数 (默认: ${process.env.TEST_ISSUE_INTERVAL || '5'})
+  --pr-interval <sec>       PR 轮询间隔秒数 (默认: ${process.env.TEST_PR_INTERVAL || '5'})
+  --issue-only              仅监听 Issue 评论
+  --pr-only                 仅监听 PR 评论
+  --duration <sec>          自动停止监听的秒数
+  --run-chat                实际调用 chat (默认模拟)
+  --chat-sha <sha>          chat 目标 SHA (默认: ${process.env.TEST_SHA || 'dev'})
+  --chat-node-version <v>   chat 容器 Node.js 版本 (默认: ${process.env.TEST_NODE_VERSION || '18'})
+  --chat-keep-container     chat 执行后保留容器
+  --chat-verbose            chat 执行输出详细日志
+  --show-prompt             打印拼装后的提示语
+  --verbose                 打印评论正文等更多信息
+  --help                    显示帮助信息
+`);
+}
+
+function expectValue(args, index, flag) {
+  if (index >= args.length) {
+    console.error(`错误: ${flag} 需要一个值`);
+    usage();
+    process.exit(1);
+  }
+  return args[index];
+}
+
+function parsePositiveNumber(raw, flag) {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    console.error(`错误: ${flag} 需要正数, 收到 ${raw}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const opts = {
+    includeIssueComments: true,
+    includePullRequestComments: true,
+    runChat: false,
+    verbose: false,
+    showPrompt: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--help':
+        usage();
+        process.exit(0);
+      case '--repo-url':
+        opts.repoUrl = expectValue(argv, ++i, '--repo-url');
+        break;
+      case '--mention':
+        opts.mention = expectValue(argv, ++i, '--mention');
+        break;
+      case '--issue-interval':
+        opts.issueIntervalSec = parsePositiveNumber(expectValue(argv, ++i, '--issue-interval'), '--issue-interval');
+        break;
+      case '--pr-interval':
+        opts.prIntervalSec = parsePositiveNumber(expectValue(argv, ++i, '--pr-interval'), '--pr-interval');
+        break;
+      case '--issue-only':
+        opts.includePullRequestComments = false;
+        break;
+      case '--pr-only':
+        opts.includeIssueComments = false;
+        break;
+      case '--duration':
+        opts.durationSec = parsePositiveNumber(expectValue(argv, ++i, '--duration'), '--duration');
+        break;
+      case '--run-chat':
+        opts.runChat = true;
+        break;
+      case '--chat-sha':
+        opts.chatSha = expectValue(argv, ++i, '--chat-sha');
+        break;
+      case '--chat-node-version':
+        opts.chatNodeVersion = expectValue(argv, ++i, '--chat-node-version');
+        break;
+      case '--chat-keep-container':
+        opts.chatKeepContainer = true;
+        break;
+      case '--chat-verbose':
+        opts.chatVerbose = true;
+        break;
+      case '--show-prompt':
+        opts.showPrompt = true;
+        break;
+      case '--verbose':
+        opts.verbose = true;
+        break;
+      default:
+        console.error(`未知选项: ${arg}`);
+        usage();
+        process.exit(1);
+    }
+  }
+
+  return opts;
+}
+
+function envNumber(name) {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function formatTimestamp() {
+  return new Date().toISOString();
+}
+
+function sourceLabel(source) {
+  return source === 'pr_review_comment' ? 'PR 评论' : 'Issue 评论';
+}
+
+function logMention(context, mentionToken, options, prompt) {
+  const header = `[${formatTimestamp()}] 🔔 检测到 ${sourceLabel(context.commentSource)} 中的 ${mentionToken}`;
+  console.log('\n' + header);
+  console.log(`   • Issue #${context.issueNumber}: ${context.issue.title}`);
+  if (context.pullRequest) {
+    console.log(`   • PR #${context.pullRequest.number}: ${context.pullRequest.title}`);
+  }
+  console.log(`   • 评论 ID: ${context.mentionComment.id}`);
+  if (options.verbose) {
+    const body = context.mentionComment.body?.trim();
+    if (body) {
+      console.log('   • 评论正文:');
+      console.log(body.split('\n').map((line) => `     ${line}`).join('\n'));
+    }
+  }
+  if (options.showPrompt) {
+    console.log('----- Prompt 开始 -----');
+    console.log(prompt);
+    console.log('----- Prompt 结束 -----');
+  }
+}
+
+function createDryRunExecutor() {
+  return async () => {
+    console.log('🤖 (dry-run) 已捕获到提及, 未实际调用 chat。');
+    return { success: true, output: 'Dry-run: chat 未执行。' };
+  };
+}
+
+function logChatResult(result, context, runChat) {
+  if (result.success) {
+    if (runChat) {
+      console.log(`✅ chat 成功 (评论 ID ${context.mentionComment.id})`);
+      if (result.output) {
+        console.log('----- chat 输出 -----');
+        console.log(result.output);
+        console.log('----------------------');
+      }
+    } else {
+      console.log(`✅ 已模拟 chat (评论 ID ${context.mentionComment.id})`);
+    }
+  } else {
+    console.error(`❌ chat 失败 (评论 ID ${context.mentionComment.id})`);
+    if (result.error) {
+      console.error(result.error);
+    }
+  }
+}
+
+function buildChatOptions(args) {
+  if (!args.runChat) return undefined;
+  const options = {};
+  const sha = args.chatSha || process.env.TEST_SHA;
+  if (sha) options.sha = sha;
+  const nodeVersion = args.chatNodeVersion || process.env.TEST_NODE_VERSION;
+  if (nodeVersion) options.nodeVersion = nodeVersion;
+  if (args.chatKeepContainer) options.keepContainer = true;
+  if (args.chatVerbose) options.verbose = true;
+  return options;
+}
+
+async function main() {
+  const args = parseArgs();
+  const repoUrl = args.repoUrl || process.env.TEST_REPO_URL;
+  if (!repoUrl) {
+    console.error('错误: 需要提供仓库 URL (--repo-url 或环境变量 TEST_REPO_URL)');
+    usage();
+    process.exit(1);
+  }
+
+  if (!args.includeIssueComments && !args.includePullRequestComments) {
+    console.error('错误: 至少需要监听 Issue 或 PR 评论中的一种');
+    process.exit(1);
+  }
+
+  const mentionToken = (args.mention || process.env.TEST_MENTION || DEFAULT_MENTION).trim();
+  const issueIntervalSec = args.issueIntervalSec || envNumber('TEST_ISSUE_INTERVAL');
+  const prIntervalSec = args.prIntervalSec || envNumber('TEST_PR_INTERVAL');
+  const durationSec = args.durationSec || envNumber('TEST_WATCH_DURATION');
+
+  const chatOptions = buildChatOptions(args);
+
+  console.log('👂 开始监听 AI 评论提及');
+  console.log(`📦 仓库: ${repoUrl}`);
+  console.log(`🏷️ 触发标记: ${mentionToken}`);
+  console.log(`📝 监听 Issue 评论: ${args.includeIssueComments ? '是' : '否'}`);
+  console.log(`📝 监听 PR 评论: ${args.includePullRequestComments ? '是' : '否'}`);
+  console.log(`🤖 chat 模式: ${args.runChat ? '实际调用' : '模拟 (dry-run)'}`);
+  if (issueIntervalSec) console.log(`⏱️ Issue 轮询间隔: ${issueIntervalSec}s`);
+  if (prIntervalSec) console.log(`⏱️ PR 轮询间隔: ${prIntervalSec}s`);
+  if (durationSec) console.log(`⌛ 自动停止: ${durationSec}s`);
+
+  const client = new GitcodeClient();
+  const timers = [];
+
+  const watcher = watchAiMentions(client, repoUrl, {
+    mention: mentionToken,
+    issueIntervalSec,
+    prIntervalSec,
+    includeIssueComments: args.includeIssueComments,
+    includePullRequestComments: args.includePullRequestComments,
+    chatOptions,
+    chatExecutor: args.runChat ? undefined : createDryRunExecutor(),
+    buildPrompt: (context) => {
+      const prompt = defaultPromptBuilder(context);
+      logMention(context, mentionToken, args, prompt);
+      return prompt;
+    },
+    onChatResult: (result, context) => {
+      logChatResult(result, context, args.runChat);
+    },
+  });
+
+  function stopWatcher(exitCode = 0) {
+    watcher.stop();
+    for (const timer of timers) {
+      clearTimeout(timer);
+    }
+    process.exit(exitCode);
+  }
+
+  process.on('SIGINT', () => {
+    console.log('\n🛑 收到 SIGINT, 正在退出...');
+    stopWatcher(0);
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('\n🛑 收到 SIGTERM, 正在退出...');
+    stopWatcher(0);
+  });
+
+  if (durationSec) {
+    timers.push(setTimeout(() => {
+      console.log('⏰ 达到设定监听时长, 自动停止');
+      stopWatcher(0);
+    }, durationSec * 1000));
+  }
+
+  console.log('✅ 监听已启动，按 Ctrl+C 可随时退出。');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('💥 监听过程中发生错误:');
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add an API helper so the Gitcode client can fetch a single issue and expose it at the package entry
- introduce core watchers for issues plus an AI mention helper that pipes @AI comments to the chat flow
- document the new utilities for watching issue comments and AI mentions
- harden the issue watcher error handling and export the default AI prompt builder for reuse, and provide a scripts/tests harness to dry-run @AI monitoring

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c82f37bf8883269c692767655130de