### PR TITLE
feat: auto reply for ai mentions

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -90,7 +90,7 @@ const watcher = watchIssues(client, 'https://gitcode.com/owner/repo.git', {
 
 ### AI 评论助手
 
-`watchAiMentions` 会同时监听 Issue 评论与 PR 评论。当新增评论中包含指定标记（默认为 `@AI`）时，会收集 Issue 标题、描述、历史评论等上下文，并将拼装后的提示语传入 `chat`。
+`watchAiMentions` 会同时监听 Issue 评论与 PR 评论。当新增评论中包含指定标记（默认为 `@AI`）时，会收集 Issue 标题、描述、历史评论等上下文，并将拼装后的提示语传入 `chat`。当 AI 调用成功且生成了内容时，会自动在对应的 Issue 或 PR 下创建回复评论。
 
 ```ts
 import { watchAiMentions } from '@gitany/core';
@@ -107,6 +107,9 @@ const aiWatcher = watchAiMentions(client, 'https://gitcode.com/owner/repo.git', 
       console.error('AI 调用失败:', result.error);
     }
   },
+  onReplyCreated: (reply) => {
+    console.log('AI 已回复评论，ID:', reply.comment.id);
+  },
 });
 
 // aiWatcher.stop();
@@ -119,6 +122,12 @@ const aiWatcher = watchAiMentions(client, 'https://gitcode.com/owner/repo.git', 
 - `issueIntervalSec` / `prIntervalSec`: Issue 与 PR 轮询频率
 - `chatExecutor`: 自定义 chat 执行器，默认使用内置 `chat`
 - `includeIssueComments` / `includePullRequestComments`: 控制监听的评论类型
+- `replyWithComment`: 是否自动在 Issue/PR 下回复评论，默认 `true`
+- `buildReplyBody(result, context)`: 自定义回复内容
+- `onReplyCreated(reply, context)`: AI 回复成功创建时的回调
+- `onReplyError(error, context)`: AI 回复失败时的回调
+
+若只希望监听但不自动回复，可设置 `replyWithComment: false`；如需对回复内容进行包装，例如附带原评论引用，可通过 `buildReplyBody` 返回自定义文本。
 
 ## 工作原理
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   AiMentionWatcherHandle,
   AiMentionContext,
   AiMentionSource,
+  AiMentionReply,
 } from './issue/ai-mentions';
 export {
   createPrContainer,

--- a/packages/gitcode/src/index.ts
+++ b/packages/gitcode/src/index.ts
@@ -31,7 +31,7 @@ export {
   prCommentSchema,
   prCommentsUrl,
 } from './api/pr';
-export type { PRComment, PRCommentQueryOptions } from './api/pr';
+export type { PRComment, PRCommentQueryOptions, CreatedPrComment } from './api/pr';
 export type {
   ListIssuesQuery,
   ListIssuesParams,

--- a/scripts/tests/test-ai-mentions.mjs
+++ b/scripts/tests/test-ai-mentions.mjs
@@ -181,6 +181,19 @@ function logChatResult(result, context, runChat) {
   }
 }
 
+function logReplySuccess(reply, context) {
+  const source = sourceLabel(reply.source);
+  console.log(`💬 已自动回复 ${source} (原评论 ID ${context.mentionComment.id})`);
+  console.log(`   • 新评论 ID: ${reply.comment.id}`);
+}
+
+function logReplyError(error, context) {
+  console.error(`⚠️ 自动回复失败 (评论 ID ${context.mentionComment.id})`);
+  if (error) {
+    console.error(error);
+  }
+}
+
 function buildChatOptions(args) {
   if (!args.runChat) return undefined;
   const options = {};
@@ -235,6 +248,7 @@ async function main() {
     includePullRequestComments: args.includePullRequestComments,
     chatOptions,
     chatExecutor: args.runChat ? undefined : createDryRunExecutor(),
+    replyWithComment: args.runChat,
     buildPrompt: (context) => {
       const prompt = defaultPromptBuilder(context);
       logMention(context, mentionToken, args, prompt);
@@ -242,6 +256,12 @@ async function main() {
     },
     onChatResult: (result, context) => {
       logChatResult(result, context, args.runChat);
+    },
+    onReplyCreated: (reply, context) => {
+      logReplySuccess(reply, context);
+    },
+    onReplyError: (error, context) => {
+      logReplyError(error, context);
     },
   });
 


### PR DESCRIPTION
## Summary
- add automatic comment replies when ai mentions succeed and expose the reply metadata
- allow customizing reply body and callbacks; update test script to log replies
- document the new behaviour and export reply type and pr comment types

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c839f27bcc8326a36d07a171a0a424