### PR TITLE
refactor test scripts to use env configuration

### DIFF
--- a/scripts/tests/test-ai-mentions.mjs
+++ b/scripts/tests/test-ai-mentions.mjs
@@ -1,5 +1,21 @@
 #!/usr/bin/env node
 
+// 环境变量:
+// - TEST_REPO_URL: 必填，目标仓库 URL。
+// - TEST_MENTION: 可选，自定义触发标记，默认值为 @AI。
+// - TEST_ISSUE_INTERVAL: 可选，Issue 轮询间隔秒数。
+// - TEST_PR_INTERVAL: 可选，PR 轮询间隔秒数。
+// - TEST_WATCH_DURATION: 可选，监听持续秒数。
+// - TEST_INCLUDE_ISSUE_COMMENTS: 可选，设置为 "false" 时不监听 Issue 评论。
+// - TEST_INCLUDE_PR_COMMENTS: 可选，设置为 "false" 时不监听 PR 评论。
+// - TEST_RUN_CHAT: 可选，设置为 "false" 时仅进行 dry-run。
+// - TEST_SHA: 可选，chat 使用的目标 SHA。
+// - TEST_NODE_VERSION: 可选，chat 容器使用的 Node.js 版本。
+// - TEST_CHAT_KEEP_CONTAINER: 可选，设置为 "true" 时保留 chat 容器。
+// - TEST_CHAT_VERBOSE: 可选，设置为 "true" 时输出 chat 详细日志。
+// - TEST_VERBOSE: 可选，设置为 "true" 时打印评论正文等调试信息。
+// - TEST_SHOW_PROMPT: 可选，设置为 "true" 时输出生成的提示词。
+
 import { config } from 'dotenv';
 import { watchAiMentions, defaultPromptBuilder, chat } from '../../packages/core/dist/index.js';
 import { GitcodeClient } from '../../packages/gitcode/dist/index.js';
@@ -8,113 +24,12 @@ config({ path: new URL('.env', import.meta.url) });
 
 const DEFAULT_MENTION = '@AI';
 
-function usage() {
-  console.log(`
-用法: node test-ai-mentions.mjs [选项]
-
-选项:
-  --repo-url <url>          仓库 URL (默认: ${process.env.TEST_REPO_URL || '无'})
-  --mention <text>          触发标记 (默认: ${process.env.TEST_MENTION || DEFAULT_MENTION})
-  --issue-interval <sec>    Issue 轮询间隔秒数 (默认: ${process.env.TEST_ISSUE_INTERVAL || '5'})
-  --pr-interval <sec>       PR 轮询间隔秒数 (默认: ${process.env.TEST_PR_INTERVAL || '5'})
-  --issue-only              仅监听 Issue 评论
-  --pr-only                 仅监听 PR 评论
-  --duration <sec>          自动停止监听的秒数
-  --run-chat                实际调用 chat (默认模拟)
-  --chat-sha <sha>          chat 目标 SHA (默认: ${process.env.TEST_SHA || 'dev'})
-  --chat-node-version <v>   chat 容器 Node.js 版本 (默认: ${process.env.TEST_NODE_VERSION || '18'})
-  --chat-keep-container     chat 执行后保留容器
-  --chat-verbose            chat 执行输出详细日志
-  --show-prompt             打印拼装后的提示语
-  --verbose                 打印评论正文等更多信息
-  --help                    显示帮助信息
-`);
-}
-
-function expectValue(args, index, flag) {
-  if (index >= args.length) {
-    console.error(`错误: ${flag} 需要一个值`);
-    usage();
-    process.exit(1);
-  }
-  return args[index];
-}
-
-function parsePositiveNumber(raw, flag) {
-  const value = Number(raw);
-  if (!Number.isFinite(value) || value <= 0) {
-    console.error(`错误: ${flag} 需要正数, 收到 ${raw}`);
-    process.exit(1);
-  }
-  return value;
-}
-
-function parseArgs() {
-  const argv = process.argv.slice(2);
-  const opts = {
-    includeIssueComments: true,
-    includePullRequestComments: true,
-    runChat: true,
-    verbose: false,
-    showPrompt: false,
-  };
-
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    switch (arg) {
-      case '--help':
-        usage();
-        process.exit(0);
-      case '--repo-url':
-        opts.repoUrl = expectValue(argv, ++i, '--repo-url');
-        break;
-      case '--mention':
-        opts.mention = expectValue(argv, ++i, '--mention');
-        break;
-      case '--issue-interval':
-        opts.issueIntervalSec = parsePositiveNumber(expectValue(argv, ++i, '--issue-interval'), '--issue-interval');
-        break;
-      case '--pr-interval':
-        opts.prIntervalSec = parsePositiveNumber(expectValue(argv, ++i, '--pr-interval'), '--pr-interval');
-        break;
-      case '--issue-only':
-        opts.includePullRequestComments = false;
-        break;
-      case '--pr-only':
-        opts.includeIssueComments = false;
-        break;
-      case '--duration':
-        opts.durationSec = parsePositiveNumber(expectValue(argv, ++i, '--duration'), '--duration');
-        break;
-      case '--run-chat':
-        opts.runChat = true;
-        break;
-      case '--chat-sha':
-        opts.chatSha = expectValue(argv, ++i, '--chat-sha');
-        break;
-      case '--chat-node-version':
-        opts.chatNodeVersion = expectValue(argv, ++i, '--chat-node-version');
-        break;
-      case '--chat-keep-container':
-        opts.chatKeepContainer = true;
-        break;
-      case '--chat-verbose':
-        opts.chatVerbose = true;
-        break;
-      case '--show-prompt':
-        opts.showPrompt = true;
-        break;
-      case '--verbose':
-        opts.verbose = true;
-        break;
-      default:
-        console.error(`未知选项: ${arg}`);
-        usage();
-        process.exit(1);
-    }
-  }
-
-  return opts;
+function envBoolean(name, defaultValue) {
+  const raw = process.env[name];
+  if (raw === undefined) return defaultValue;
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
 }
 
 function envNumber(name) {
@@ -226,68 +141,80 @@ function logReplyError(error, context) {
   }
 }
 
-function buildChatOptions(args) {
-  if (!args.runChat) return undefined;
+function buildChatOptions(runChat, chatKeepContainer, chatVerbose) {
+  if (!runChat) return undefined;
   const options = {};
-  const sha = args.chatSha || process.env.TEST_SHA;
+  const sha = (process.env.TEST_SHA || '').trim();
   if (sha) options.sha = sha;
-  const nodeVersion = args.chatNodeVersion || process.env.TEST_NODE_VERSION;
+  const nodeVersion = (process.env.TEST_NODE_VERSION || '').trim();
   if (nodeVersion) options.nodeVersion = nodeVersion;
-  if (args.chatKeepContainer) options.keepContainer = true;
-  if (args.chatVerbose) options.verbose = true;
+  if (chatKeepContainer) options.keepContainer = true;
+  if (chatVerbose) options.verbose = true;
   return options;
 }
 
 async function main() {
-  const args = parseArgs();
-  const repoUrl = args.repoUrl || process.env.TEST_REPO_URL;
+  const repoUrl = (process.env.TEST_REPO_URL || '').trim();
   if (!repoUrl) {
-    console.error('错误: 需要提供仓库 URL (--repo-url 或环境变量 TEST_REPO_URL)');
-    usage();
+    console.error('错误: 请设置 TEST_REPO_URL 环境变量。');
     process.exit(1);
   }
 
-  if (!args.includeIssueComments && !args.includePullRequestComments) {
+  const includeIssueComments = envBoolean('TEST_INCLUDE_ISSUE_COMMENTS', true);
+  const includePullRequestComments = envBoolean('TEST_INCLUDE_PR_COMMENTS', true);
+  if (!includeIssueComments && !includePullRequestComments) {
     console.error('错误: 至少需要监听 Issue 或 PR 评论中的一种');
     process.exit(1);
   }
 
-  const mentionToken = (args.mention || process.env.TEST_MENTION || DEFAULT_MENTION).trim();
-  const issueIntervalSec = args.issueIntervalSec || envNumber('TEST_ISSUE_INTERVAL');
-  const prIntervalSec = args.prIntervalSec || envNumber('TEST_PR_INTERVAL');
-  const durationSec = args.durationSec || envNumber('TEST_WATCH_DURATION');
+  const mentionToken = (process.env.TEST_MENTION || DEFAULT_MENTION).trim();
+  const issueIntervalSec = envNumber('TEST_ISSUE_INTERVAL');
+  const prIntervalSec = envNumber('TEST_PR_INTERVAL');
+  const durationSec = envNumber('TEST_WATCH_DURATION');
+  const runChat = envBoolean('TEST_RUN_CHAT', true);
+  const verbose = envBoolean('TEST_VERBOSE', false);
+  const showPrompt = envBoolean('TEST_SHOW_PROMPT', false);
+  const chatKeepContainer = envBoolean('TEST_CHAT_KEEP_CONTAINER', false);
+  const chatVerbose = envBoolean('TEST_CHAT_VERBOSE', false);
 
-  const chatOptions = buildChatOptions(args);
+  const chatOptions = buildChatOptions(runChat, chatKeepContainer, chatVerbose);
 
   console.log('👂 开始监听 AI 评论提及');
   console.log(`📦 仓库: ${repoUrl}`);
   console.log(`🏷️ 触发标记: ${mentionToken}`);
-  console.log(`📝 监听 Issue 评论: ${args.includeIssueComments ? '是' : '否'}`);
-  console.log(`📝 监听 PR 评论: ${args.includePullRequestComments ? '是' : '否'}`);
-  console.log(`🤖 chat 模式: ${args.runChat ? '实际调用' : '模拟 (dry-run)'}`);
+  console.log(`📝 监听 Issue 评论: ${includeIssueComments ? '是' : '否'}`);
+  console.log(`📝 监听 PR 评论: ${includePullRequestComments ? '是' : '否'}`);
+  console.log(`🤖 chat 模式: ${runChat ? '实际调用' : '模拟 (dry-run)'}`);
+  if (chatOptions?.sha) console.log(`🔗 chat 目标: ${chatOptions.sha}`);
+  if (chatOptions?.nodeVersion) console.log(`🟢 chat Node.js 版本: ${chatOptions.nodeVersion}`);
+  if (chatKeepContainer) console.log('🐳 chat 执行后将保留容器');
+  if (chatVerbose) console.log('🔍 chat 详细日志: 开启');
   if (issueIntervalSec) console.log(`⏱️ Issue 轮询间隔: ${issueIntervalSec}s`);
   if (prIntervalSec) console.log(`⏱️ PR 轮询间隔: ${prIntervalSec}s`);
   if (durationSec) console.log(`⌛ 自动停止: ${durationSec}s`);
+  if (showPrompt) console.log('📝 将输出生成的提示词');
+  if (verbose) console.log('🔍 将打印评论正文等调试信息');
 
   const client = new GitcodeClient();
   const timers = [];
+  const loggingOptions = { verbose, showPrompt };
 
   const watcher = watchAiMentions(client, repoUrl, {
     mention: mentionToken,
     issueIntervalSec,
     prIntervalSec,
-    includeIssueComments: args.includeIssueComments,
-    includePullRequestComments: args.includePullRequestComments,
+    includeIssueComments,
+    includePullRequestComments,
     chatOptions,
-    chatExecutor: args.runChat ? createLoggedChatExecutor() : createDryRunExecutor(),
-    replyWithComment: args.runChat,
+    chatExecutor: runChat ? createLoggedChatExecutor() : createDryRunExecutor(),
+    replyWithComment: runChat,
     buildPrompt: (context) => {
       const prompt = defaultPromptBuilder(context);
-      logMention(context, mentionToken, args, prompt);
+      logMention(context, mentionToken, loggingOptions, prompt);
       return prompt;
     },
     onChatResult: (result, context) => {
-      logChatResult(result, context, args.runChat);
+      logChatResult(result, context, runChat);
     },
     onReplyCreated: (reply, context) => {
       logReplySuccess(reply, context);

--- a/scripts/tests/test-claude-chat.mjs
+++ b/scripts/tests/test-claude-chat.mjs
@@ -1,76 +1,37 @@
 #!/usr/bin/env node
 
+// 环境变量:
+// - TEST_REPO_URL: 必填，目标仓库 URL。
+// - TEST_QUESTION: 必填，要提交给 chat 的问题或提示词。
+// - TEST_SHA: 可选，chat 检查的目标提交或分支，默认 dev。
+// - TEST_NODE_VERSION: 可选，chat 容器使用的 Node.js 版本，默认 18。
+// - TEST_VERBOSE: 可选，设置为 "true" 时输出详细日志。
+// - TEST_KEEP_CONTAINER: 可选，设置为 "true" 时保留执行容器。
+
 import { chat } from '../../packages/core/dist/index.js';
 import { config } from 'dotenv';
 
 // 加载环境变量 (.env 文件可选)
 config({ path: new URL('.env', import.meta.url) });
 
-function usage() {
-  console.log(`
-用法: node test-claude-chat.mjs [选项]
-
-选项:
-  --repo-url <url>       仓库 URL (默认: ${process.env.TEST_REPO_URL})
-  --question <text>      提问内容 (默认: ${process.env.TEST_QUESTION})
-  --sha <hash>           目标 SHA 或分支 (默认: ${process.env.TEST_SHA || 'dev'})
-  --node-version <v>     Node.js 版本 (默认: ${process.env.TEST_NODE_VERSION || '18'})
-  --verbose, -v          显示详细输出
-  --keep-container, -k   保留容器用于调试
-  --help                 显示帮助信息
-`);
-}
-
-function parseArgs() {
-  const args = process.argv.slice(2);
-  const opts = { verbose: false, keepContainer: false };
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    switch (arg) {
-      case '--repo-url':
-        opts.repoUrl = args[++i];
-        break;
-      case '--question':
-        opts.question = args[++i];
-        break;
-      case '--sha':
-        opts.sha = args[++i];
-        break;
-      case '--node-version':
-        opts.nodeVersion = args[++i];
-        break;
-      case '--verbose':
-      case '-v':
-        opts.verbose = true;
-        break;
-      case '--keep-container':
-      case '-k':
-        opts.keepContainer = true;
-        break;
-      case '--help':
-        usage();
-        process.exit(0);
-      default:
-        console.error(`未知选项: ${arg}`);
-        usage();
-        process.exit(1);
-    }
-  }
-  return opts;
+function envBoolean(name, defaultValue) {
+  const raw = process.env[name];
+  if (raw === undefined) return defaultValue;
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
 }
 
 async function main() {
-  const args = parseArgs();
-  const repoUrl = args.repoUrl || process.env.TEST_REPO_URL;
-  const question = args.question || process.env.TEST_QUESTION;
-  const sha = args.sha || process.env.TEST_SHA || 'dev';
-  const nodeVersion = args.nodeVersion || process.env.TEST_NODE_VERSION || '18';
-  const verbose = args.verbose;
-  const keepContainer = args.keepContainer;
+  const repoUrl = (process.env.TEST_REPO_URL || '').trim();
+  const question = (process.env.TEST_QUESTION || '').trim();
+  const sha = (process.env.TEST_SHA || 'dev').trim();
+  const nodeVersion = (process.env.TEST_NODE_VERSION || '18').trim();
+  const verbose = envBoolean('TEST_VERBOSE', false);
+  const keepContainer = envBoolean('TEST_KEEP_CONTAINER', false);
 
   if (!repoUrl || !question) {
-    console.error('错误: 需要提供仓库 URL 和提问内容');
-    usage();
+    console.error('错误: 请设置 TEST_REPO_URL 和 TEST_QUESTION 环境变量。');
     process.exit(1);
   }
 

--- a/scripts/tests/test-claude-install.mjs
+++ b/scripts/tests/test-claude-install.mjs
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+// 环境变量:
+// - TEST_NODE_VERSION: 可选，Docker 容器使用的 Node.js 版本，默认 20。
+// - TEST_VERBOSE: 可选，设置为 "true" 时输出详细安装日志。
+// - TEST_KEEP_CONTAINER: 可选，设置为 "true" 时在测试结束后保留容器。
+
 import Docker from '../../packages/core/node_modules/dockerode/lib/docker.js';
 import { createLogger } from '../../packages/shared/dist/index.js';
 import {
@@ -7,49 +12,18 @@ import {
   installClaudeCli,
 } from '../../packages/core/dist/index.js';
 
-function parseArgs() {
-  const args = process.argv.slice(2);
-  const options = {
-    nodeVersion: '20',
-    verbose: false,
-    keepContainer: false,
-  };
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    switch (arg) {
-      case '--node-version':
-        options.nodeVersion = args[++i];
-        break;
-      case '--verbose':
-      case '-v':
-        options.verbose = true;
-        break;
-      case '--keep-container':
-      case '-k':
-        options.keepContainer = true;
-        break;
-      case '--help':
-        console.log(`
-用法: node test-claude-install.mjs [选项]
-
-选项:
-  --node-version <v>     Node.js 版本 (默认: 20)
-  --verbose, -v          显示详细输出
-  --keep-container, -k   保留容器用于调试
-  --help                 显示帮助信息
-`);
-        process.exit(0);
-        break;
-      default:
-        console.error(`未知选项: ${arg}`);
-        process.exit(1);
-    }
-  }
-  return options;
+function envBoolean(name, defaultValue) {
+  const raw = process.env[name];
+  if (raw === undefined) return defaultValue;
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
 }
 
 async function main() {
-  const { nodeVersion, verbose, keepContainer } = parseArgs();
+  const nodeVersion = (process.env.TEST_NODE_VERSION || '20').trim();
+  const verbose = envBoolean('TEST_VERBOSE', false);
+  const keepContainer = envBoolean('TEST_KEEP_CONTAINER', false);
 
   const docker = new Docker();
   const log = createLogger('test:claude-install');
@@ -63,6 +37,10 @@ async function main() {
 
   try {
     console.log('⏳ 正在安装 Claude CLI...');
+    console.log(`🟢 Node.js 版本: ${nodeVersion}`);
+    if (verbose) {
+      console.log('🔍 详细模式: 开启');
+    }
     const result = await installClaudeCli({ container, log, verbose });
     if (verbose || !result.success) {
       console.log(result.output);

--- a/scripts/tests/test-pnpm-build.mjs
+++ b/scripts/tests/test-pnpm-build.mjs
@@ -1,32 +1,27 @@
 #!/usr/bin/env node
 
+// 环境变量:
+// - TEST_REPO_URL: 必填，目标仓库 URL。
+// - TEST_SHA: 必填，要测试的提交 SHA 或分支。
+// - TEST_NODE_VERSION: 可选，Docker 容器使用的 Node.js 版本，默认 18。
+// - TEST_VERBOSE: 可选，设置为 "true" 时输出详细日志。
+// - TEST_KEEP_CONTAINER: 可选，设置为 "true" 时保留构建容器用于调试。
+
 import { testShaBuild } from '../../packages/core/dist/index.js';
 import { config } from 'dotenv';
 
 // 加载环境变量
 config({ path: new URL('.env', import.meta.url) });
 
-function usage() {
-  console.log(`
-用法: node test-pnpm-build.mjs [选项]
-
-选项:
-  --repo-url <url>       仓库 URL (默认: ${process.env.TEST_REPO_URL})
-  --sha <hash>           提交 SHA 哈希 (默认: ${process.env.TEST_SHA})
-  --node-version <v>     Node.js 版本 (默认: ${process.env.TEST_NODE_VERSION || 18})
-  --verbose, -v          显示详细输出
-  --keep-container, -k   保留容器用于调试
-  --help                 显示帮助信息
-
-示例:
-  node test-pnpm-build.mjs
-  node test-pnpm-build.mjs --repo-url https://gitcode.com/user/repo --sha abc123
-  node test-pnpm-build.mjs --node-version 20 --verbose
-  node test-pnpm-build.mjs --keep-container
-`);
+function envBoolean(name, defaultValue) {
+  const raw = process.env[name];
+  if (raw === undefined) return defaultValue;
+  const normalized = raw.trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
 }
 
-function showTroubleshootingGuide(result) {
+function showTroubleshootingGuide(result, repoUrl) {
   console.log('');
   console.log('🔧 故障排除指南:');
   console.log('');
@@ -43,7 +38,9 @@ function showTroubleshootingGuide(result) {
     console.log('❌ 仓库访问问题:');
     console.log('   - 检查仓库 URL 是否正确');
     console.log('   - 确认仓库是公开的或你有访问权限');
-    console.log('   - 测试克隆: git clone ' + process.env.TEST_REPO_URL);
+    if (repoUrl) {
+      console.log(`   - 测试克隆: git clone ${repoUrl}`);
+    }
     console.log('');
   }
 
@@ -111,8 +108,8 @@ function showTroubleshootingGuide(result) {
   }
 
   console.log('💡 调试建议:');
-  console.log('   1. 使用 --verbose 参数查看详细输出');
-  console.log('   2. 使用 --keep-container 保留容器进行手动调试');
+  console.log('   1. 将 TEST_VERBOSE 设置为 true 查看详细输出');
+  console.log('   2. 将 TEST_KEEP_CONTAINER 设置为 true 保留容器进行手动调试');
   console.log('   3. 检查网络连接和代理设置');
   console.log('   4. 验证 Node.js 版本兼容性');
   console.log('   5. 确认项目确实是 pnpm 项目');
@@ -122,67 +119,16 @@ function showTroubleshootingGuide(result) {
   console.log('');
 }
 
-function parseArgs() {
-  const args = process.argv.slice(2);
-  const options = {};
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    switch (arg) {
-      case '--help':
-        usage();
-        process.exit(0);
-
-      case '--repo-url':
-        options.repoUrl = args[++i];
-        break;
-
-      case '--sha':
-        options.sha = args[++i];
-        break;
-
-      case '--node-version':
-        options.nodeVersion = args[++i];
-        break;
-
-      case '--verbose':
-      case '-v':
-        options.verbose = true;
-        break;
-
-      case '--keep-container':
-      case '-k':
-        options.keepContainer = true;
-        break;
-
-      default:
-        console.error(`未知选项: ${arg}`);
-        usage();
-        process.exit(1);
-    }
-  }
-
-  return options;
-}
-
 async function main() {
   try {
-    // 解析命令行参数
-    const cliArgs = parseArgs();
+    const repoUrl = (process.env.TEST_REPO_URL || '').trim();
+    const sha = (process.env.TEST_SHA || '').trim();
+    const nodeVersion = (process.env.TEST_NODE_VERSION || '18').trim();
+    const verbose = envBoolean('TEST_VERBOSE', false);
+    const keepContainer = envBoolean('TEST_KEEP_CONTAINER', false);
 
-    // 配置测试参数
-    const repoUrl = cliArgs.repoUrl || process.env.TEST_REPO_URL;
-    const sha = cliArgs.sha || process.env.TEST_SHA;
-    const nodeVersion = cliArgs.nodeVersion || process.env.TEST_NODE_VERSION || '18';
-    const verbose = cliArgs.verbose || false;
-    const keepContainer = cliArgs.keepContainer || false;
-
-    // 验证必要参数
     if (!repoUrl || !sha) {
-      console.error('错误: 请提供仓库 URL 和 SHA 提交哈希');
-      console.log('可以通过命令行参数或环境变量 TEST_REPO_URL 和 TEST_SHA 设置');
-      usage();
+      console.error('错误: 请设置 TEST_REPO_URL 和 TEST_SHA 环境变量。');
       process.exit(1);
     }
 
@@ -190,8 +136,8 @@ async function main() {
     console.log(`📦 仓库: ${repoUrl}`);
     console.log(`🔗 SHA: ${sha}`);
     console.log(`🟢 Node.js 版本: ${nodeVersion}`);
-    if (verbose) console.log(`🔍 详细模式: 开启`);
-    if (keepContainer) console.log(`🐳 保留容器: 开启`);
+    if (verbose) console.log('🔍 详细模式: 开启');
+    if (keepContainer) console.log('🐳 保留容器: 开启');
     console.log('');
 
     // 执行测试
@@ -201,7 +147,7 @@ async function main() {
     const result = await testShaBuild(repoUrl, sha, {
       nodeVersion,
       verbose,
-      keepContainer
+      keepContainer,
     });
 
     const totalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
@@ -248,7 +194,7 @@ async function main() {
       console.log(`   错误: ${result.error || '未知错误'}`);
 
       // 显示故障排除指南
-      showTroubleshootingGuide(result);
+      showTroubleshootingGuide(result, repoUrl);
 
       if (keepContainer && result.diagnostics.containerId) {
         console.log(`🐳 容器已保留用于调试，ID: ${result.diagnostics.containerId}`);


### PR DESCRIPTION
## Summary
- document required environment variables at the top of each test script in scripts/tests
- drop interactive CLI parsing in the test scripts and rely solely on environment variables
- update the scripts to read booleans/numbers from env vars and improve logging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c93250f44c83268b95eeb5197ade4f