### PR TITLE
Remove CLI web flags

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -280,9 +280,6 @@ gitcode pr comment 123 --editor
 # 从标准输入读取评论内容
 echo "这是一个评论" | gitcode pr comment 123 --body-file -
 
-# 在浏览器中创建评论
-gitcode pr comment 123 --web
-
 # 输出 JSON 格式
 gitcode pr comment 123 --body "测试评论" --json
 ```
@@ -291,7 +288,6 @@ gitcode pr comment 123 --body "测试评论" --json
   - `--body <string>`：指定评论内容
   - `-F, --body-file <file>`：从文件读取评论内容（使用 `-` 从标准输入读取）
   - `-e, --editor`：打开文本编辑器编写评论
-  - `-w, --web`：在浏览器中创建评论
   - `--json`：输出原始 JSON 格式
   - `-R, --repo <[HOST/]OWNER/REPO>`：指定其他仓库
 - 调用：`POST /api/v5/repos/{owner}/{repo}/pulls/{number}/comments`

--- a/docs/cli/issue.md
+++ b/docs/cli/issue.md
@@ -85,7 +85,6 @@ gitcode issue create [owner] [repo] [title] [options]
 - `-m, --milestone <number>`: Add the issue to a milestone by number
 - `--security-hole <security-hole>`: Security hole level
 - `--template-path <template-path>`: Template path
-- `-w, --web`: Open the browser to create an issue
 - `--json`: Output raw JSON instead of formatted output
 - `-R, --repo <[HOST/]OWNER/REPO>`: Select another repository using the [HOST/]OWNER/REPO format
 
@@ -129,7 +128,6 @@ gitcode issue comment <issue> [body] [options]
 - `-b, --body <string>`: Supply a comment body
 - `-F, --body-file <file>`: Read body text from file (use "-" to read from standard input)
 - `-e, --editor`: Open text editor to write the comment
-- `-w, --web`: Open the browser to create a comment
 - `--json`: Output raw JSON instead of formatted output
 - `-R, --repo <[HOST/]OWNER/REPO>`: Select another repository using the [HOST/]OWNER/REPO format
 

--- a/packages/cli/src/commands/issue/create-comment.ts
+++ b/packages/cli/src/commands/issue/create-comment.ts
@@ -9,7 +9,6 @@ interface CreateCommentOptions {
   body?: string;
   bodyFile?: string;
   editor?: boolean;
-  web?: boolean;
   json?: boolean;
   repo?: string;
 }
@@ -90,12 +89,6 @@ export async function createCommentAction(
       throw new Error('Invalid issue number');
     }
 
-    if (options.web) {
-      const url = `https://gitcode.com/${owner}/${repo}/issues/${issueNumber}#new_comment_field`;
-      console.log(`Opening ${url} in your browser...`);
-      return;
-    }
-
     let finalBody = bodyArg || options.body || '';
 
     if (options.bodyFile) {
@@ -155,7 +148,6 @@ export function createCommentCommand(): Command {
     .option('-b, --body <string>', 'Supply a comment body')
     .option('-F, --body-file <file>', 'Read body text from file (use "-" to read from standard input)')
     .option('-e, --editor', 'Open text editor to write the comment')
-    .option('-w, --web', 'Open the browser to create a comment')
     .option('--json', 'Output raw JSON instead of formatted output')
     .option('-R, --repo <[HOST/]OWNER/REPO>', 'Select another repository using the [HOST/]OWNER/REPO format')
     .action(createCommentAction);

--- a/packages/cli/src/commands/issue/create.ts
+++ b/packages/cli/src/commands/issue/create.ts
@@ -16,7 +16,6 @@ export interface CreateOptions {
   template_path?: string;
   bodyFile?: string;
   editor?: boolean;
-  web?: boolean;
   json?: boolean;
   repo?: string;
 }
@@ -60,15 +59,6 @@ async function openEditor(content: string): Promise<string> {
 
 export async function createAction(owner: string, repo: string, title?: string, options: CreateOptions = {}) {
   await withClient(async (client) => {
-    
-    // 如果指定了 web 模式，打开浏览器
-    if (options.web) {
-      const url = `https://gitcode.com/${owner}/${repo}/issues/new`;
-      console.log(`Opening ${url} in your browser...`);
-      // 在真实环境中，这里应该使用 open 或类似包
-      return;
-    }
-
     // 获取 title（交互式提示）
     let finalTitle = title || options.title;
     if (!finalTitle) {
@@ -197,7 +187,6 @@ export function createCommand(): Command {
     .option('-m, --milestone <number>', 'Add the issue to a milestone by number', (val) => parseInt(val, 10))
     .option('--security-hole <security-hole>', 'Security hole level')
     .option('--template-path <template-path>', 'Template path')
-    .option('-w, --web', 'Open the browser to create an issue')
     .option('--json', 'Output raw JSON instead of formatted output')
     .option('-R, --repo <[HOST/]OWNER/REPO>', 'Select another repository using the [HOST/]OWNER/REPO format')
     .action(async (ownerArg?: string, repoArg?: string, titleArg?: string, options?: CreateOptions) => {

--- a/packages/cli/src/commands/pr/create-comment.ts
+++ b/packages/cli/src/commands/pr/create-comment.ts
@@ -13,7 +13,6 @@ interface CreatePrCommentOptions {
   body?: string;
   bodyFile?: string;
   editor?: boolean;
-  web?: boolean;
   json?: boolean;
   repo?: string;
 }
@@ -58,23 +57,10 @@ export async function createPrCommentAction(
       throw new Error('Unrecognized repository URL. Provide a full git URL or run inside a git repo.');
     }
 
-    const owner = parsed.owner;
-    const repo = parsed.repo;
-    const host = parsed.host || 'gitcode.com';
     const prNum = parseInt(prNumber, 10);
 
     if (isNaN(prNum)) {
       throw new Error('Invalid PR number');
-    }
-
-    // 如果指定了 web 模式，打开浏览器
-    // TODO 移除web模式及相关代码
-    if (options.web) {
-      const url = `https://${host}/${owner}/${repo}/pull/${prNum}#new_comment_field`;
-      const openMsg = `Opening ${url} in your browser...`;
-      console.log(openMsg);
-      logger.info({ url }, openMsg);
-      return;
     }
 
     const comment = await client.pr.createComment(repoUrl, prNum, body);
@@ -129,7 +115,6 @@ export function createPrCommentCommand(): Command {
     .option('--body <string>', 'Supply a comment body')
     .option('-F, --body-file <file>', 'Read body text from file (use "-" to read from standard input)')
     .option('-e, --editor', 'Open text editor to write the comment')
-    .option('-w, --web', 'Open the browser to create a comment')
     .option('--json', 'Output raw JSON instead of formatted output')
     .option('-R, --repo <[HOST/]OWNER/REPO>', 'Select another repository using the [HOST/]OWNER/REPO format')
     .action(async (


### PR DESCRIPTION
## Summary
- remove the deprecated `--web` option from issue creation and commenting commands
- clean up the PR comment command implementation to drop unused web-specific logic
- update the CLI documentation so the removed flag is no longer advertised

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9385d9db883268cd05d61b2cfe8a2