### PR TITLE
Require AI replies in Chinese

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -129,6 +129,8 @@ const aiWatcher = watchAiMentions(client, 'https://gitcode.com/owner/repo.git', 
 
 若只希望监听但不自动回复，可设置 `replyWithComment: false`；如需对回复内容进行包装，例如附带原评论引用，可通过 `buildReplyBody` 返回自定义文本。
 
+默认提示语会包含仓库、Issue 与评论上下文，并明确要求 AI 使用中文进行回复。
+
 ## 工作原理
 
 - 按指定间隔检查 PR 列表（默认 5 秒）

--- a/packages/core/src/issue/ai-mentions.ts
+++ b/packages/core/src/issue/ai-mentions.ts
@@ -377,6 +377,7 @@ export function defaultPromptBuilder(context: AiMentionContext): string {
   );
   lines.push(mentionComment.body);
   lines.push('Provide a helpful answer or recommended next steps for the maintainers.');
+  lines.push('Your entire reply must be written in Simplified Chinese.');
 
   return lines.join('\n\n');
 }


### PR DESCRIPTION
## Summary
- add an explicit instruction to the default AI mention prompt so replies must be in Simplified Chinese
- note in the core documentation that the built-in prompt requests Chinese responses

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9423f561c83269774ba48be41766d