### PR TITLE
Log each issue watcher poll

### DIFF
--- a/packages/core/src/issue/watcher.ts
+++ b/packages/core/src/issue/watcher.ts
@@ -48,12 +48,15 @@ export function watchIssues(
   const state = createWatcherState(url);
 
   const check = async () => {
+    const startedAt = Date.now();
+    logger.info({ url }, '[watchIssues] poll start');
     try {
       const { data: issues } = await fetchIssues(client, url, options);
       await detectNewComments(client, url, issues, state, options);
       await persistState(url, state);
+      logger.info({ url, durationMs: Date.now() - startedAt }, '[watchIssues] poll complete');
     } catch (err) {
-      logger.error({ err, url }, '[watchIssues] poll failed');
+      logger.error({ err, url, durationMs: Date.now() - startedAt }, '[watchIssues] poll failed');
     }
   };
 


### PR DESCRIPTION
## Summary
- log when an issue watcher poll starts and finishes
- include poll duration in success and failure logs for easier tracing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c95d7b2b1c8326bee74a229f2a98a9