### PR TITLE
Implement congestion-controlled polling for GitCode watchers

### DIFF
--- a/docs/gitcode/index.md
+++ b/docs/gitcode/index.md
@@ -56,10 +56,13 @@ title: gitcode 工具库
 - `Authorization: Bearer <token>`
 
 请求在网络连接失败时会自动重试 3 次，可通过 `retries` 选项自定义。
+请求会在发起前经过全局限流队列（默认每 60 秒最多 50 次请求，可通过 `GITCODE_API_RPM` 调整）。
+可通过 `getHttpRateLimiterStats()` 获取当前限流队列长度与速率配置，便于上层轮询逻辑根据拥塞情况动态退避。
 
 环境变量：
 
 - `GITCODE_TOKEN`：令牌（优先级高于磁盘存储）
+- `GITCODE_API_RPM`：可选，配置每分钟允许的最大请求数（默认 50）
 
 **Token 读取优先级**：
 1. 环境变量 `GITCODE_TOKEN`
@@ -156,4 +159,4 @@ parseGitUrl('git@gitcode.com:owner/repo.git');
 
 ### 历史变更
 
-- 内部已统一使用 `utils/http.ts` 的 `httpRequest` 进行网络请求，实现 URL 构建、头部合并、鉴权与错误处理的集中管理，并通过 ETag 自动缓存未变更的响应；对外 API 与行为不变。
+- 内部已统一使用 `utils/http.ts` 的 `httpRequest` 进行网络请求，实现 URL 构建、头部合并、鉴权与错误处理的集中管理，并通过 ETag 自动缓存未变更的响应；请求在发送前会经过全局限流（默认 60 秒 50 次，可通过 `GITCODE_API_RPM` 配置）；对外 API 与行为不变。

--- a/packages/core/src/utils/polling.ts
+++ b/packages/core/src/utils/polling.ts
@@ -1,0 +1,145 @@
+import { performance } from 'node:perf_hooks';
+
+export interface PollLogger {
+  debug?: (details: Record<string, unknown>, message?: string) => void;
+  info?: (details: Record<string, unknown>, message?: string) => void;
+  warn?: (details: Record<string, unknown>, message?: string) => void;
+  error?: (details: Record<string, unknown>, message?: string) => void;
+}
+
+export interface AdaptivePollerOptions {
+  /** Human readable label used for logging. */
+  label: string;
+  /** Baseline interval configured by the caller (in milliseconds). */
+  baseIntervalMs: number;
+  /** Maximum requests per minute allowed by the upstream GitCode client. */
+  rpm: number;
+  /** Function that returns the current queue size from the HTTP limiter. */
+  getLimiterQueueSize: () => number;
+  /** Optional logger for debugging and congestion/backoff reporting. */
+  logger?: PollLogger;
+  /** Number of enqueued requests tolerated before triggering congestion. */
+  backlogThreshold?: number;
+  /** Multiplier applied to the scheduled interval to detect slow polls. */
+  latencyMultiplier?: number;
+  /** Smallest interval the poller is allowed to use (milliseconds). */
+  minIntervalMs?: number;
+  /** Largest interval the poller can grow to (milliseconds). */
+  maxIntervalMs?: number;
+  /** Upper bound for the congestion window. */
+  maxCwnd?: number;
+  /** Initial congestion window, defaults to 1. */
+  initialCwnd?: number;
+  /** Callback invoked when the work function throws. */
+  onError?: (error: unknown) => void;
+}
+
+export interface AdaptivePollerHandle {
+  stop(): void;
+  /** Snapshot of the current congestion control window and interval. */
+  readonly stats: () => { cwnd: number; ssthresh: number; intervalMs: number };
+}
+
+export function createAdaptivePoller(
+  work: () => Promise<void>,
+  options: AdaptivePollerOptions,
+): AdaptivePollerHandle {
+  const label = options.label ?? 'poller';
+  const rpm = Math.max(1, Math.floor(options.rpm));
+  const backlogThreshold = options.backlogThreshold ?? 0;
+  const latencyMultiplier = options.latencyMultiplier ?? 1.25;
+  const minIntervalConfig = options.minIntervalMs ?? Math.min(options.baseIntervalMs, 1_000);
+  const minIntervalMs = Math.max(250, minIntervalConfig);
+  const maxIntervalMs = Math.max(
+    minIntervalMs,
+    options.maxIntervalMs ?? Math.max(options.baseIntervalMs, 60_000),
+  );
+  const maxCwnd = Math.max(1, options.maxCwnd ?? rpm);
+  const minCwnd = 1;
+
+  let cwnd = Math.min(Math.max(options.initialCwnd ?? 1, minCwnd), maxCwnd);
+  let ssthresh = Math.min(maxCwnd, Math.max(Math.floor(maxCwnd / 2), minCwnd));
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const computeInterval = () => {
+    const throttleInterval = 60_000 / (rpm * Math.max(cwnd, 1));
+    const baseScaled = options.baseIntervalMs / Math.max(cwnd, 1);
+    let interval = Math.max(throttleInterval, baseScaled, minIntervalMs);
+    interval = Math.min(interval, maxIntervalMs);
+    return interval;
+  };
+
+  let currentIntervalMs = computeInterval();
+
+  const run = async () => {
+    if (stopped) {
+      return;
+    }
+
+    const scheduledInterval = currentIntervalMs;
+    const start = performance.now();
+    let didError = false;
+
+    try {
+      await work();
+    } catch (err) {
+      didError = true;
+      options.onError?.(err);
+    }
+
+    const duration = performance.now() - start;
+    let queueSize = Number(options.getLimiterQueueSize?.() ?? 0);
+    if (!Number.isFinite(queueSize) || queueSize < 0) {
+      queueSize = 0;
+    }
+
+    const congested =
+      didError ||
+      queueSize > backlogThreshold ||
+      duration > scheduledInterval * latencyMultiplier;
+
+    if (congested) {
+      const nextSsthresh = Math.max(minCwnd, Math.floor(cwnd / 2));
+      ssthresh = Math.max(nextSsthresh, minCwnd);
+      cwnd = minCwnd;
+      options.logger?.warn?.(
+        { queueSize, duration, cwnd, ssthresh, scheduledInterval },
+        `[${label}] congestion detected, backing off`,
+      );
+    } else {
+      const previous = cwnd;
+      if (cwnd < ssthresh) {
+        cwnd = Math.min(maxCwnd, cwnd * 2);
+      } else {
+        cwnd = Math.min(maxCwnd, cwnd + 1);
+      }
+      options.logger?.debug?.(
+        { queueSize, duration, cwnd, previous, scheduledInterval },
+        `[${label}] poll completed`,
+      );
+    }
+
+    currentIntervalMs = computeInterval();
+
+    if (!stopped) {
+      timer = setTimeout(() => {
+        void run();
+      }, currentIntervalMs);
+      timer.unref?.();
+    }
+  };
+
+  void run();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+    stats: () => ({ cwnd, ssthresh, intervalMs: currentIntervalMs }),
+  };
+}

--- a/packages/gitcode/package.json
+++ b/packages/gitcode/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@gitany/shared": "workspace:*",
+    "p-throttle": "^5.1.0",
     "zod": "^4.1.7"
   }
 }

--- a/packages/gitcode/src/utils/index.ts
+++ b/packages/gitcode/src/utils/index.ts
@@ -49,4 +49,5 @@ export function toQuery<T extends object | undefined | null>(
   return out;
 }
 
-export { isNotModified } from './http';
+export { isNotModified, getHttpRateLimiterStats } from './http';
+export type { HttpRateLimiterStats } from './http';


### PR DESCRIPTION
## Summary
- queue GitCode HTTP requests through a shared p-throttle limiter before calling fetch
- allow tuning the limiter via the GITCODE_API_RPM environment variable while keeping a 50 rpm default
- document the new rate limiting behavior and configuration in the GitCode package docs
- expose limiter statistics via `getHttpRateLimiterStats()` so pollers can react to backlog conditions
- replace fixed-interval PR/issue pollers with a TCP-style congestion controller that dynamically adjusts their schedule, now defaulting to a 30-second base interval, and document the adaptive behaviour

## Testing
- pnpm lint
- pnpm --filter @gitany/shared build
- pnpm --filter @gitany/gitcode build
- pnpm --filter @gitany/core build

------
https://chatgpt.com/codex/tasks/task_e_68c952dc6344832696359439f40f4775