### PR TITLE
Add configurable rate limiter for Gitcode HTTP requests

### DIFF
--- a/docs/gitcode/index.md
+++ b/docs/gitcode/index.md
@@ -58,6 +58,7 @@ title: gitcode 工具库
 环境变量：
 
 - `GITCODE_TOKEN`：令牌（优先级高于磁盘存储）
+- `GITCODE_API_RPM`：每分钟允许的请求数（默认 50，用于调试或调整限流队列）
 
 **Token 读取优先级**：
 1. 环境变量 `GITCODE_TOKEN`
@@ -151,3 +152,4 @@ parseGitUrl('git@gitcode.com:owner/repo.git');
 ### 历史变更
 
 - 内部已统一使用 `utils/http.ts` 的 `httpRequest` 进行网络请求，实现 URL 构建、头部合并、鉴权与错误处理的集中管理，并通过 ETag 自动缓存未变更的响应；对外 API 与行为不变。
+- `httpRequest` 现支持全局限流队列，默认每分钟最多 50 次请求，并会在队列积压时指数级延长轮询间隔；可通过环境变量 `GITCODE_API_RPM` 进行调节以便调试或应对不同限额。

--- a/packages/gitcode/src/utils/http.ts
+++ b/packages/gitcode/src/utils/http.ts
@@ -11,6 +11,18 @@ export interface HttpRequestOptions {
   body?: string;
 }
 
+const DEFAULT_REQUESTS_PER_MINUTE = 50;
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+const requestsPerMinute = resolveRequestsPerMinute();
+const baseIntervalMs = Math.max(Math.ceil(60000 / requestsPerMinute), 1);
+
+type QueueResolver = () => void;
+
+const requestQueue: QueueResolver[] = [];
+let processingQueue = false;
+let lastDispatchTimestamp = Date.now() - baseIntervalMs;
+
 // Simple in-memory cache for ETag and payload per URL
 const etagStore = new Map<string, { etag: string; payload: unknown }>();
 const cacheHit = new WeakSet<object>();
@@ -45,6 +57,8 @@ export async function httpRequest<T = unknown>(params: HttpRequestParams): Promi
   if (options?.body !== undefined) {
     init.body = options.body;
   }
+
+  await waitForThrottleTurn();
 
   const resp = await fetch(requestUrl, init);
 
@@ -95,4 +109,80 @@ function buildUrlWithQuery(url: string, query?: Record<string, string | number |
     u.searchParams.append(k, String(v));
   });
   return u.toString();
+}
+
+async function waitForThrottleTurn(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    requestQueue.push(resolve);
+    void runQueue();
+  });
+}
+
+async function runQueue(): Promise<void> {
+  if (processingQueue) {
+    return;
+  }
+  processingQueue = true;
+  try {
+    while (requestQueue.length > 0) {
+      await ensureThrottleWindow();
+      lastDispatchTimestamp = Date.now();
+      const next = requestQueue.shift();
+      next?.();
+    }
+  } finally {
+    processingQueue = false;
+    if (requestQueue.length > 0) {
+      void runQueue();
+    }
+  }
+}
+
+async function ensureThrottleWindow(): Promise<void> {
+  while (true) {
+    const queueSize = requestQueue.length;
+    const requiredInterval = calculateInterval(queueSize);
+    const now = Date.now();
+    const elapsed = now - lastDispatchTimestamp;
+    const waitTime = requiredInterval - elapsed;
+    if (waitTime <= 0) {
+      return;
+    }
+    await sleep(waitTime);
+  }
+}
+
+function calculateInterval(queueSize: number): number {
+  if (queueSize <= 0) {
+    return baseIntervalMs;
+  }
+  const multiplier = Math.floor(queueSize / requestsPerMinute);
+  if (multiplier <= 0) {
+    return baseIntervalMs;
+  }
+  const maxMultiplier = Math.max(0, Math.floor(Math.log2(MAX_TIMER_DELAY_MS / baseIntervalMs)));
+  const cappedMultiplier = Math.min(multiplier, maxMultiplier);
+  const scaled = baseIntervalMs * Math.pow(2, cappedMultiplier);
+  return Math.min(scaled, MAX_TIMER_DELAY_MS);
+}
+
+function resolveRequestsPerMinute(): number {
+  const envValue =
+    typeof process !== 'undefined' && process.env ? process.env.GITCODE_API_RPM : undefined;
+  if (envValue) {
+    const parsed = Number(envValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.max(1, Math.floor(parsed));
+    }
+  }
+  return DEFAULT_REQUESTS_PER_MINUTE;
+}
+
+async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, Math.min(ms, MAX_TIMER_DELAY_MS));
+  });
 }


### PR DESCRIPTION
## Summary
- introduce a global request queue in `httpRequest` that enforces the default 50 rpm limit before calling `fetch`
- make the limiter interval grow exponentially when the queue size crosses multiples of the rpm cap and allow overriding via `GITCODE_API_RPM`
- document the new environment variable and throttling behaviour in the GitCode package docs

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c96f90245083269b3df026ccf40a69