### PR TITLE
refactor(run-ai-mentions): remove legacy username fallback

### DIFF
--- a/scripts/run-ai-mentions.mjs
+++ b/scripts/run-ai-mentions.mjs
@@ -25,17 +25,6 @@ import os from 'node:os';
 
 config({ path: new URL('.env', import.meta.url) });
 
-function resolveLocalUsername() {
-  try {
-    const username = os.userInfo().username?.trim();
-    if (username) return username;
-  } catch (error) {
-    // ignore - fall back to legacy default below
-  }
-
-  return undefined;
-}
-
 async function resolveDefaultMention(client, verbose) {
   try {
     const profile = await client.user.getProfile();
@@ -43,13 +32,10 @@ async function resolveDefaultMention(client, verbose) {
     if (login) return `@${login}`;
   } catch (error) {
     if (verbose) {
-      console.warn('⚠️ 无法从 Gitcode 获取当前用户名, 将使用本地用户名或默认值 @AI。');
+      console.warn('⚠️ 无法从 Gitcode 获取当前用户名, 将使用默认值 @AI。');
       console.warn(error);
     }
   }
-
-  const localUsername = resolveLocalUsername();
-  if (localUsername) return `@${localUsername}`;
 
   return '@AI';
 }


### PR DESCRIPTION
This commit removes the fallback logic that used the local OS username when the GitCode username could not be fetched. This is a breaking change that simplifies the script and removes a potential source of inconsistency. The script will now always use the GitCode username or a hardcoded default, as intended.

## 变更内容

- （简述本次改动）

## 文档同步检查

- [ ] 我已同步更新文档（docs/*）或此改动不影响对外接口
  - 影响 gitcode 库 → docs/gitcode
  - 影响 CLI → docs/cli

## 自检清单

- [ ] 通过 `pnpm build`
- [ ] 通过 `pnpm lint` / `pnpm format`
- [ ] 如需，附上截图或输出示例

