### PR TITLE
Add timestamps to issue schemas and tighten CLI typings

### DIFF
--- a/docs/gitcode/issue.md
+++ b/docs/gitcode/issue.md
@@ -19,10 +19,10 @@ title: Issues API
 
 - `ListIssuesQuery`：Issue 列表查询参数（`state`、`labels`、`page`、`per_page`、`sort`）。
 - `ListIssuesParams`：包含 `owner`、`repo` 与可选 `query`。
-- `Issue`：Issue 的最小字段表示（`id`、`html_url`、`number`、`state`、`title`、`body`、`user`）。
+- `Issue`：Issue 的最小字段表示（`id`、`html_url`、`number`、`state`、`title`、`body`、`user`、`assignees`、`labels`、`created_at`、`updated_at`）。
 - `ListIssuesResponse`：`Issue[]`。
 - `IssueCommentsQuery`：Issue 评论查询参数（`page`、`per_page`）。
-- `IssueComment`：Issue 评论的最小字段表示（`id`、`body`、`user`）。
+- `IssueComment`：Issue 评论的最小字段表示（`id`、`comment_id?`、`body`、`user`、`created_at?`、`updated_at?`）。
 - `IssueCommentsResponse`：`IssueComment[]`。
 - `listIssuesUrl(owner, repo)`：构建列表接口绝对 URL。
 - `issueCommentsUrl(owner, repo, number)`：构建评论列表接口绝对 URL。

--- a/packages/gitcode-cli/src/commands/issue/edit.ts
+++ b/packages/gitcode-cli/src/commands/issue/edit.ts
@@ -1,5 +1,4 @@
 import type { UpdateIssueBody, UpdatedIssue } from '@gitany/gitcode';
-import { isObjectLike } from '@gitany/gitcode';
 import { Command } from 'commander';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
@@ -90,15 +89,14 @@ export async function editAction(
       console.log(`   State: ${colorizeState(issue.state)}`);
       console.log(`   URL: ${colors.blue}${issue.html_url}${colors.reset}`);
 
-      const labels = (issue as { labels?: unknown }).labels;
-      if (Array.isArray(labels) && labels.length > 0) {
-        const labelNames = labels
+      if (issue.labels.length > 0) {
+        const labelNames = issue.labels
           .map((label) => {
-            if (!isObjectLike(label)) {
-              return String(label ?? '');
-            }
-            const record = label as Record<string, unknown>;
-            return String(record.name ?? record.title ?? record.id ?? '');
+            if (label.name) return label.name;
+            if (label.title) return label.title;
+            if (typeof label.id === 'string' && label.id) return label.id;
+            if (typeof label.id === 'number') return String(label.id);
+            return '';
           })
           .filter(Boolean)
           .join(', ');

--- a/packages/gitcode/src/api/issue/comments.ts
+++ b/packages/gitcode/src/api/issue/comments.ts
@@ -5,6 +5,7 @@
 
 import { z } from 'zod';
 import { API_BASE } from '../constants';
+import { userSummarySchema } from '../user/summary';
 
 /** Query parameters for listing issue comments. */
 export interface IssueCommentsQuery {
@@ -17,8 +18,9 @@ export interface IssueCommentsQuery {
 /** Minimal Issue Comment representation. */
 export const issueCommentSchema = z.object({
   id: z.number(),
+  comment_id: z.number().optional(),
   body: z.string(),
-  user: z.unknown(),
+  user: userSummarySchema.optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });

--- a/packages/gitcode/src/api/issue/list.ts
+++ b/packages/gitcode/src/api/issue/list.ts
@@ -41,6 +41,16 @@ export type ListIssuesParams = {
  */
 export type IssueUser = UserSummary;
 
+const issueLabelSchema = z
+  .object({
+    id: z.union([z.number(), z.string()]).optional(),
+    name: z.string().optional(),
+    title: z.string().optional(),
+    color: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .passthrough();
+
 export const issueSchema = z.object({
   id: z.number(),
   html_url: z.string(),
@@ -50,6 +60,9 @@ export const issueSchema = z.object({
   body: z.string().nullable().optional(),
   user: userSummarySchema.optional(),
   assignees: z.array(userSummarySchema).default([]),
+  labels: z.array(issueLabelSchema).default([]),
+  created_at: z.string(),
+  updated_at: z.string(),
 });
 
 export type Issue = z.infer<typeof issueSchema>;


### PR DESCRIPTION
## Summary
- extend issue and comment schemas with timestamp fields and richer label/user data
- update CLI issue view/edit commands to rely on the stricter typings and simplify rendering
- refresh issue documentation to describe the new fields

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68de8095bc94832697090412b42edeb8