### PR TITLE
Simplify PR comment author lookup

### DIFF
--- a/packages/gitcode-cli/src/commands/pr/comments.ts
+++ b/packages/gitcode-cli/src/commands/pr/comments.ts
@@ -1,5 +1,4 @@
 import type { PRComment, PRCommentQueryOptions } from '@gitany/gitcode';
-import { isObjectLike } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
 import { resolveRepoUrl } from '@gitany/git-lib';
 import { withClient } from '../../utils/with-client';
@@ -41,9 +40,7 @@ export async function prCommentsCommand(
       for (const comment of comments) {
         const id = comment.id;
         const bodyFirstLine = comment.body.split('\n')[0] ?? '';
-        const author = (isObjectLike(comment.user)
-          ? (comment.user as { id?: string }).id
-          : undefined) || '?';
+        const author = comment.user?.id ?? '?';
         console.log(`- [#${id}] ${author}: ${bodyFirstLine}`);
       }
     },


### PR DESCRIPTION
## Summary
- simplify the PR comments author display by using optional chaining on the user
- remove the unused `isObjectLike` helper import

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de80a00dcc83268bb956c6dc5f11cb