### PR TITLE
refactor: centralize repo option typing

### DIFF
--- a/packages/git-lib/src/index.ts
+++ b/packages/git-lib/src/index.ts
@@ -1,4 +1,5 @@
 export type { GitResult, GitExecOptions } from './types';
 export { GitClient } from './client';
 export { resolveRepoUrl } from './utils';
+export type { ResolvedRepoUrl, ResolvedRepoResource } from './utils';
 export { GitNotFoundError } from './errors';

--- a/packages/git-lib/src/index.ts
+++ b/packages/git-lib/src/index.ts
@@ -1,5 +1,5 @@
 export type { GitResult, GitExecOptions } from './types';
 export { GitClient } from './client';
-export { resolveRepoUrl } from './utils';
+export { resolveRepoUrl, parseRepoUrl } from './utils';
 export type { ResolvedRepoUrl, ResolvedRepoResource } from './utils';
 export { GitNotFoundError } from './errors';

--- a/packages/git-lib/src/utils/index.ts
+++ b/packages/git-lib/src/utils/index.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 
-export { resolveRepoUrl } from './resolve-repo-url';
+export { resolveRepoUrl, parseRepoUrl } from './resolve-repo-url';
 export type { ResolvedRepoUrl, ResolvedRepoResource } from './resolve-repo-url';
 
 export function expandCwd(cwd?: string) {

--- a/packages/git-lib/src/utils/index.ts
+++ b/packages/git-lib/src/utils/index.ts
@@ -2,6 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 export { resolveRepoUrl } from './resolve-repo-url';
+export type { ResolvedRepoUrl, ResolvedRepoResource } from './resolve-repo-url';
 
 export function expandCwd(cwd?: string) {
   if (!cwd) return cwd;

--- a/packages/git-lib/src/utils/resolve-repo-url.ts
+++ b/packages/git-lib/src/utils/resolve-repo-url.ts
@@ -1,39 +1,198 @@
 import { GitClient } from '../client';
 import { GitNotFoundError } from '../errors';
 
-function normalizeRepoUrlInput(raw: string): string {
-  const url = raw.trim();
-  if (!url) {
+const DEFAULT_HOST = 'gitcode.com';
+
+function stripGitSuffix(segment: string): string {
+  return segment.replace(/\.git$/i, '');
+}
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function sanitizeResourceSegment(segment: string | undefined): string | undefined {
+  if (!segment) return undefined;
+  const withoutQuery = segment.split('?')[0];
+  const withoutFragment = withoutQuery.split('#')[0];
+  return decodeSegment(stripGitSuffix(withoutFragment));
+}
+
+function parseResourceNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const normalized = value.startsWith('#') ? value.slice(1) : value;
+  if (!/^\d+$/.test(normalized)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+export type ResolvedRepoResource =
+  | { type: 'issue'; number: number }
+  | { type: 'pull'; number: number };
+
+export interface ResolvedRepoUrl {
+  repoUrl: string;
+  owner?: string;
+  repo?: string;
+  host?: string;
+  resource?: ResolvedRepoResource;
+}
+
+function parseResource(
+  segments: string[],
+  hash?: string,
+): ResolvedRepoResource | undefined {
+  if (segments.length > 0) {
+    const [firstRaw, secondRaw] = segments;
+    const first = sanitizeResourceSegment(firstRaw)?.toLowerCase();
+    const second = sanitizeResourceSegment(secondRaw);
+
+    if (first && ['issue', 'issues'].includes(first)) {
+      const number = parseResourceNumber(second);
+      if (number !== undefined) {
+        return { type: 'issue', number };
+      }
+    }
+
+    if (first && ['pull', 'pulls', 'pr'].includes(first)) {
+      const number = parseResourceNumber(second);
+      if (number !== undefined) {
+        return { type: 'pull', number };
+      }
+    }
+
+    const direct = sanitizeResourceSegment(firstRaw);
+    const directNumber = parseResourceNumber(direct);
+    if (directNumber !== undefined) {
+      return { type: 'issue', number: directNumber };
+    }
+  }
+
+  if (hash) {
+    const number = parseResourceNumber(hash);
+    if (number !== undefined) {
+      return { type: 'issue', number };
+    }
+  }
+
+  return undefined;
+}
+
+function buildResolved(
+  protocol: string | undefined,
+  host: string,
+  owner: string,
+  repo: string,
+  resourceSegments: string[],
+  hash?: string,
+): ResolvedRepoUrl {
+  const normalizedProtocol = protocol === 'http:' ? 'http' : 'https';
+  const repoUrl = `${normalizedProtocol}://${host}/${owner}/${repo}`;
+  const resource = parseResource(resourceSegments, hash);
+  return { host, owner, repo, repoUrl, resource };
+}
+
+function parseHttpLikeUrl(raw: string): ResolvedRepoUrl | undefined {
+  try {
+    const url = new URL(raw);
+    if (!url.hostname) return undefined;
+    const segments = url.pathname
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => decodeSegment(segment));
+    if (segments.length < 2) return undefined;
+    const owner = segments[0];
+    const repo = stripGitSuffix(segments[1]);
+    const resourceSegments = segments.slice(2);
+    return buildResolved(url.protocol, url.host, owner, repo, resourceSegments, url.hash);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseSshUrl(raw: string): ResolvedRepoUrl | undefined {
+  const match = raw.match(/^git@([^:]+):(.+)$/i);
+  if (!match) return undefined;
+  const [, host, path] = match;
+  const segments = path
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => decodeSegment(segment));
+  if (segments.length < 2) return undefined;
+  const owner = segments[0];
+  const repo = stripGitSuffix(segments[1]);
+  const resourceSegments = segments.slice(2);
+  return buildResolved('https:', host, owner, repo, resourceSegments);
+}
+
+function parseShorthand(raw: string): ResolvedRepoUrl | undefined {
+  let input = raw.trim();
+  if (!input) return undefined;
+
+  let hash: string | undefined;
+  const hashIndex = input.indexOf('#');
+  if (hashIndex >= 0) {
+    hash = input.slice(hashIndex + 1);
+    input = input.slice(0, hashIndex);
+  }
+
+  const segments = input
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => decodeSegment(segment));
+
+  if (segments.length < 2) return undefined;
+
+  let host = DEFAULT_HOST;
+  let ownerIndex = 0;
+  if (segments.length >= 3 && segments[0].includes('.')) {
+    host = segments[0];
+    ownerIndex = 1;
+  }
+
+  const owner = segments[ownerIndex];
+  const repo = stripGitSuffix(segments[ownerIndex + 1]);
+  const resourceSegments = segments.slice(ownerIndex + 2);
+  return buildResolved('https:', host, owner, repo, resourceSegments, hash);
+}
+
+function normalizeRepoUrlInput(raw: string): ResolvedRepoUrl {
+  const trimmed = raw.trim();
+  if (!trimmed) {
     throw new Error('Repository URL cannot be empty');
   }
 
-  // Already an absolute HTTP/HTTPS/SSH URL (e.g., https://, git@)
-  if (/^(?:https?:\/\/|git@)/i.test(url)) {
-    return url;
+  const parsedHttp = parseHttpLikeUrl(trimmed);
+  if (parsedHttp) {
+    return parsedHttp;
   }
 
-  // OWNER/REPO
-  const ownerRepo = url.match(/^([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
-  if (ownerRepo) {
-    const [, owner, repo] = ownerRepo;
-    return `https://gitcode.com/${owner}/${repo}`;
+  const parsedSsh = parseSshUrl(trimmed);
+  if (parsedSsh) {
+    return parsedSsh;
   }
 
-  // HOST/OWNER/REPO (no scheme provided)
-  const hostOwnerRepo = url.match(/^([\w.-]+)\/([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
-  if (hostOwnerRepo) {
-    const [, host, owner, repo] = hostOwnerRepo;
-    return `https://${host}/${owner}/${repo}`;
+  const parsedShorthand = parseShorthand(trimmed);
+  if (parsedShorthand) {
+    return parsedShorthand;
   }
 
-  return url;
+  return { repoUrl: trimmed };
 }
 
 export async function resolveRepoUrl(
   url?: string,
   options: { cwd?: string } = {},
-): Promise<string> {
-  if (url) return normalizeRepoUrlInput(url);
+): Promise<ResolvedRepoUrl> {
+  if (url) {
+    return normalizeRepoUrlInput(url);
+  }
   const client = new GitClient(options.cwd);
   try {
     const result = await client.run(['remote', 'get-url', 'origin']);
@@ -43,7 +202,7 @@ export async function resolveRepoUrl(
           'Failed to get remote URL. Provide repository URL or run inside a git repo.',
       );
     }
-    return result.stdout.trim();
+    return normalizeRepoUrlInput(result.stdout.trim());
   } catch (err) {
     if (err instanceof GitNotFoundError) {
       throw new GitNotFoundError('git not found. Provide repository URL or install git.');

--- a/packages/git-lib/src/utils/resolve-repo-url.ts
+++ b/packages/git-lib/src/utils/resolve-repo-url.ts
@@ -162,7 +162,7 @@ function parseShorthand(raw: string): ResolvedRepoUrl | undefined {
   return buildResolved('https:', host, owner, repo, resourceSegments, hash);
 }
 
-function normalizeRepoUrlInput(raw: string): ResolvedRepoUrl {
+export function parseRepoUrl(raw: string): ResolvedRepoUrl {
   const trimmed = raw.trim();
   if (!trimmed) {
     throw new Error('Repository URL cannot be empty');
@@ -191,7 +191,7 @@ export async function resolveRepoUrl(
   options: { cwd?: string } = {},
 ): Promise<ResolvedRepoUrl> {
   if (url) {
-    return normalizeRepoUrlInput(url);
+    return parseRepoUrl(url);
   }
   const client = new GitClient(options.cwd);
   try {
@@ -202,7 +202,7 @@ export async function resolveRepoUrl(
           'Failed to get remote URL. Provide repository URL or run inside a git repo.',
       );
     }
-    return normalizeRepoUrlInput(result.stdout.trim());
+    return parseRepoUrl(result.stdout.trim());
   } catch (err) {
     if (err instanceof GitNotFoundError) {
       throw new GitNotFoundError('git not found. Provide repository URL or install git.');

--- a/packages/gitcode-cli/src/commands/issue/close.ts
+++ b/packages/gitcode-cli/src/commands/issue/close.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { withClient } from '../../utils/with-client';
-import { colorizeState, colors, resolveIssueContext, type IssueTargetOptions } from './helpers';
+import { colorizeState, colors, resolveIssueContext, type RepoOption } from './helpers';
 
-interface CloseOptions extends IssueTargetOptions {
+interface CloseOptions extends RepoOption {
   json?: boolean;
 }
 

--- a/packages/gitcode-cli/src/commands/issue/close.ts
+++ b/packages/gitcode-cli/src/commands/issue/close.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { withClient } from '../../utils/with-client';
-import { colorizeState, colors, resolveIssueContext, type RepoOption } from './helpers';
+import { colorizeState, colors, resolveIssueContext } from './helpers';
 
-interface CloseOptions extends RepoOption {
+interface CloseOptions {
   json?: boolean;
 }
 
@@ -13,7 +13,7 @@ export async function closeAction(
 ) {
   await withClient(
     async (client) => {
-      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg, options);
+      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg);
 
       const issue = await client.issue.update(repoUrl, issueNumber, { state: 'closed' });
 
@@ -48,9 +48,5 @@ export function closeCommand(): Command {
     .argument('<number>', 'Issue number')
     .argument('[url]', 'Repository URL')
     .option('--json', 'Output raw JSON instead of formatted text')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(closeAction);
 }

--- a/packages/gitcode-cli/src/commands/issue/create-comment.ts
+++ b/packages/gitcode-cli/src/commands/issue/create-comment.ts
@@ -2,12 +2,12 @@ import { Command } from 'commander';
 import { parseGitUrl } from '@gitany/gitcode';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
+import { type RepoOption } from './helpers';
 
-interface CreateCommentOptions {
+interface CreateCommentOptions extends RepoOption {
   body?: string;
   bodyFile?: string;
   json?: boolean;
-  repo?: string;
 }
 
 export async function createCommentAction(

--- a/packages/gitcode-cli/src/commands/issue/create-comment.ts
+++ b/packages/gitcode-cli/src/commands/issue/create-comment.ts
@@ -1,10 +1,8 @@
 import { Command } from 'commander';
-import { parseGitUrl } from '@gitany/gitcode';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
-import { type RepoOption } from './helpers';
 
-interface CreateCommentOptions extends RepoOption {
+interface CreateCommentOptions {
   body?: string;
   bodyFile?: string;
   json?: boolean;
@@ -16,47 +14,26 @@ export async function createCommentAction(
   options: CreateCommentOptions = {},
 ) {
   await withClient(async (client) => {
-    // 处理 --repo 标志和解析 issue 参数
+    // 解析 issue 参数
     let owner: string;
     let repo: string;
     let issueNumber: number;
 
-    if (options.repo) {
-      const parsed = parseGitUrl(options.repo);
-      if (parsed) {
-        owner = parsed.owner;
-        repo = parsed.repo;
-      } else {
-        const parts = options.repo.split('/');
-        if (parts.length === 3) {
-          owner = parts[1];
-          repo = parts[2];
-        } else if (parts.length === 2) {
-          owner = parts[0];
-          repo = parts[1];
-        } else {
-          throw new Error(`Invalid repository format: "${options.repo}". Use [HOST/]OWNER/REPO`);
-        }
-      }
-
-      issueNumber = parseInt(issueArg, 10);
+    const urlMatch = issueArg.match(/^(?:https?:\/\/)?([^/]+)\/([^/]+)\/issues\/(\d+)$/);
+    if (urlMatch) {
+      owner = urlMatch[1];
+      repo = urlMatch[2];
+      issueNumber = parseInt(urlMatch[3], 10);
     } else {
-      const urlMatch = issueArg.match(/^(?:https?:\/\/)?([^/]+)\/([^/]+)\/issues\/(\d+)$/);
-      if (urlMatch) {
-        owner = urlMatch[1];
-        repo = urlMatch[2];
-        issueNumber = parseInt(urlMatch[3], 10);
+      const parts = issueArg.split('/');
+      if (parts.length === 3) {
+        owner = parts[0];
+        repo = parts[1];
+        issueNumber = parseInt(parts[2], 10);
       } else {
-        const parts = issueArg.split('/');
-        if (parts.length === 3) {
-          owner = parts[0];
-          repo = parts[1];
-          issueNumber = parseInt(parts[2], 10);
-        } else {
-          throw new Error(
-            'Invalid issue format. Use OWNER/REPO/NUMBER or https://gitcode.com/OWNER/REPO/issues/NUMBER',
-          );
-        }
+        throw new Error(
+          'Invalid issue format. Use OWNER/REPO/NUMBER or https://gitcode.com/OWNER/REPO/issues/NUMBER',
+        );
       }
     }
 
@@ -122,9 +99,5 @@ export function createCommentCommand(): Command {
     .option('-b, --body <string>', 'Supply a comment body')
     .option('-F, --body-file <file>', 'Read body text from a file')
     .option('--json', 'Output raw JSON instead of formatted output')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(createCommentAction);
 }

--- a/packages/gitcode-cli/src/commands/issue/create-comment.ts
+++ b/packages/gitcode-cli/src/commands/issue/create-comment.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { resolveRepoUrl } from '@gitany/git-lib';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
 
@@ -14,32 +15,17 @@ export async function createCommentAction(
   options: CreateCommentOptions = {},
 ) {
   await withClient(async (client) => {
-    // 解析 issue 参数
-    let owner: string;
-    let repo: string;
-    let issueNumber: number;
-
-    const urlMatch = issueArg.match(/^(?:https?:\/\/)?([^/]+)\/([^/]+)\/issues\/(\d+)$/);
-    if (urlMatch) {
-      owner = urlMatch[1];
-      repo = urlMatch[2];
-      issueNumber = parseInt(urlMatch[3], 10);
-    } else {
-      const parts = issueArg.split('/');
-      if (parts.length === 3) {
-        owner = parts[0];
-        repo = parts[1];
-        issueNumber = parseInt(parts[2], 10);
-      } else {
-        throw new Error(
-          'Invalid issue format. Use OWNER/REPO/NUMBER or https://gitcode.com/OWNER/REPO/issues/NUMBER',
-        );
-      }
+    const resolved = await resolveRepoUrl(issueArg);
+    const issueResource = resolved.resource;
+    if (!resolved.owner || !resolved.repo || issueResource?.type !== 'issue') {
+      throw new Error(
+        'Invalid issue format. Use OWNER/REPO/NUMBER or https://gitcode.com/OWNER/REPO/issues/NUMBER',
+      );
     }
 
-    if (isNaN(issueNumber)) {
-      throw new Error('Invalid issue number');
-    }
+    const owner = resolved.owner;
+    const repo = resolved.repo;
+    const issueNumber = issueResource.number;
 
     let finalBody = bodyArg || options.body || '';
 

--- a/packages/gitcode-cli/src/commands/issue/create.ts
+++ b/packages/gitcode-cli/src/commands/issue/create.ts
@@ -5,9 +5,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { withClient } from '../../utils/with-client';
-import { formatAssignees } from './helpers';
+import { formatAssignees, type RepoOption } from './helpers';
 
-export interface CreateOptions {
+export interface CreateOptions extends RepoOption {
   title?: string;
   body?: string;
   assignee?: string;
@@ -18,7 +18,6 @@ export interface CreateOptions {
   bodyFile?: string;
   editor?: boolean;
   json?: boolean;
-  repo?: string;
 }
 
 // 模拟交互式提示（简化版本）

--- a/packages/gitcode-cli/src/commands/issue/create.ts
+++ b/packages/gitcode-cli/src/commands/issue/create.ts
@@ -1,13 +1,14 @@
 import { Command } from 'commander';
 import { parseGitUrl } from '@gitany/gitcode';
 import type { CreateIssueBody, CreatedIssue } from '@gitany/gitcode';
+import { resolveRepoUrl } from '@gitany/git-lib';
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { withClient } from '../../utils/with-client';
-import { formatAssignees, type RepoOption } from './helpers';
+import { formatAssignees } from './helpers';
 
-export interface CreateOptions extends RepoOption {
+export interface CreateOptions {
   title?: string;
   body?: string;
   assignee?: string;
@@ -58,14 +59,21 @@ async function openEditor(content: string): Promise<string> {
 }
 
 export async function createAction(
-  owner: string,
-  repo: string,
-  title?: string,
+  repoUrlArg: string | undefined,
+  titleArg: string | undefined,
   options: CreateOptions = {},
 ) {
   await withClient(async (client) => {
+    const repoUrl = await resolveRepoUrl(repoUrlArg);
+    const parsedRepo = parseGitUrl(repoUrl);
+    if (!parsedRepo) {
+      throw new Error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
+    }
+
+    const { owner, repo } = parsedRepo;
+
     // 获取 title（交互式提示）
-    let finalTitle = title || options.title;
+    let finalTitle = titleArg ?? options.title;
     if (!finalTitle) {
       finalTitle = await promptForInput('Title');
       if (!finalTitle) {
@@ -181,11 +189,7 @@ function getStateColor(state: string): string {
 export function createCommand(): Command {
   return new Command('create')
     .description('Create a new issue')
-    .argument(
-      '[owner]',
-      'Repository owner (user or organization) - can be omitted if --repo is used',
-    )
-    .argument('[repo]', 'Repository name - can be omitted if --repo is used')
+    .argument('[url]', 'Repository URL or OWNER/REPO (defaults to current git remote)')
     .argument('[title]', 'Issue title - will prompt if not provided')
     .option('-t, --title <string>', 'Supply a title. Will prompt for one otherwise')
     .option('-b, --body <string>', 'Supply a body. Will prompt for one otherwise')
@@ -206,41 +210,19 @@ export function createCommand(): Command {
     .option('--security-hole <security-hole>', 'Security hole level')
     .option('--template-path <template-path>', 'Template path')
     .option('--json', 'Output raw JSON instead of formatted output')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(
-      async (ownerArg?: string, repoArg?: string, titleArg?: string, options?: CreateOptions) => {
+      async (repoArg?: string, titleArg?: string, options?: CreateOptions) => {
         const optionsToUse = options || {};
 
-        // 处理 --repo 标志
-        if (optionsToUse.repo) {
-          const parsed = parseGitUrl(optionsToUse.repo);
-          if (parsed) {
-            ownerArg = parsed.owner;
-            repoArg = parsed.repo;
-          } else {
-            const parts = optionsToUse.repo.split('/');
-            if (parts.length === 3) {
-              ownerArg = parts[1];
-              repoArg = parts[2];
-            } else if (parts.length === 2) {
-              ownerArg = parts[0];
-              repoArg = parts[1];
-            } else {
-              throw new Error('Invalid repository format. Use [HOST/]OWNER/REPO');
-            }
-          }
+        let repoInput = repoArg?.trim() || undefined;
+        let titleInput = titleArg;
+
+        if (repoInput && !/^(?:https?:\/\/|git@)/i.test(repoInput) && !repoInput.includes('/')) {
+          titleInput = titleInput ?? repoInput;
+          repoInput = undefined;
         }
 
-        if (!ownerArg || !repoArg) {
-          throw new Error(
-            'Repository owner and name are required. Use --repo OWNER/REPO or provide as arguments',
-          );
-        }
-
-        await createAction(ownerArg, repoArg, titleArg || optionsToUse.title, optionsToUse);
+        await createAction(repoInput, titleInput, optionsToUse);
       },
     );
 }

--- a/packages/gitcode-cli/src/commands/issue/create.ts
+++ b/packages/gitcode-cli/src/commands/issue/create.ts
@@ -64,13 +64,17 @@ export async function createAction(
   options: CreateOptions = {},
 ) {
   await withClient(async (client) => {
-    const repoUrl = await resolveRepoUrl(repoUrlArg);
-    const parsedRepo = parseGitUrl(repoUrl);
-    if (!parsedRepo) {
-      throw new Error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
+    const resolved = await resolveRepoUrl(repoUrlArg);
+    let owner = resolved.owner;
+    let repo = resolved.repo;
+    if (!owner || !repo) {
+      const parsedRepo = parseGitUrl(resolved.repoUrl);
+      if (!parsedRepo) {
+        throw new Error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
+      }
+      owner = parsedRepo.owner;
+      repo = parsedRepo.repo;
     }
-
-    const { owner, repo } = parsedRepo;
 
     // 获取 title（交互式提示）
     let finalTitle = titleArg ?? options.title;

--- a/packages/gitcode-cli/src/commands/issue/edit-comment.ts
+++ b/packages/gitcode-cli/src/commands/issue/edit-comment.ts
@@ -3,14 +3,14 @@ import { parseGitUrl } from '@gitany/gitcode';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
 import { createLogger } from '@gitany/shared';
+import { type RepoOption } from './helpers';
 
 const logger = createLogger('cli:issue:edit-comment');
 
-interface EditCommentOptions {
+interface EditCommentOptions extends RepoOption {
   body?: string;
   bodyFile?: string;
   json?: boolean;
-  repo?: string;
 }
 
 export async function editCommentAction(commentIdArg: string, options: EditCommentOptions = {}) {

--- a/packages/gitcode-cli/src/commands/issue/edit-comment.ts
+++ b/packages/gitcode-cli/src/commands/issue/edit-comment.ts
@@ -1,28 +1,29 @@
 import { Command } from 'commander';
 import { parseGitUrl } from '@gitany/gitcode';
+import { resolveRepoUrl } from '@gitany/git-lib';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
 import { createLogger } from '@gitany/shared';
-import { type RepoOption } from './helpers';
 
 const logger = createLogger('cli:issue:edit-comment');
 
-interface EditCommentOptions extends RepoOption {
+interface EditCommentOptions {
   body?: string;
   bodyFile?: string;
   json?: boolean;
 }
 
-export async function editCommentAction(commentIdArg: string, options: EditCommentOptions = {}) {
+export async function editCommentAction(
+  commentIdArg: string,
+  urlArg?: string,
+  options: EditCommentOptions = {},
+) {
   await withClient(async (client) => {
-    if (!options.repo) {
-      throw new Error('The --repo flag is required when editing a comment.');
-    }
-
-    const parsedRepo = parseGitUrl(options.repo);
+    const repoUrl = await resolveRepoUrl(urlArg);
+    const parsedRepo = parseGitUrl(repoUrl);
     if (!parsedRepo) {
       throw new Error(
-        `Invalid repository format: "${options.repo}". Use OWNER/REPO or a full URL.`,
+        'Unrecognized repository URL. Provide OWNER/REPO or a full git URL.',
       );
     }
     const { owner, repo } = parsedRepo;
@@ -65,9 +66,9 @@ export function editCommentCommand(): Command {
   return new Command('edit-comment')
     .description('Edit a comment on an issue')
     .argument('<comment-id>', 'The ID of the comment to edit')
+    .argument('[url]', 'Repository URL or OWNER/REPO')
     .option('-b, --body <string>', 'New comment body')
     .option('-F, --body-file <file>', 'Read new body text from a file')
-    .option('-R, --repo <OWNER/REPO>', 'Specify the repository (required)')
     .option('--json', 'Output raw JSON')
     .action(editCommentAction);
 }

--- a/packages/gitcode-cli/src/commands/issue/edit-comment.ts
+++ b/packages/gitcode-cli/src/commands/issue/edit-comment.ts
@@ -19,14 +19,20 @@ export async function editCommentAction(
   options: EditCommentOptions = {},
 ) {
   await withClient(async (client) => {
-    const repoUrl = await resolveRepoUrl(urlArg);
-    const parsedRepo = parseGitUrl(repoUrl);
-    if (!parsedRepo) {
-      throw new Error(
-        'Unrecognized repository URL. Provide OWNER/REPO or a full git URL.',
-      );
+    const resolved = await resolveRepoUrl(urlArg);
+    let owner = resolved.owner;
+    let repo = resolved.repo;
+
+    if (!owner || !repo) {
+      const parsedRepo = parseGitUrl(resolved.repoUrl);
+      if (!parsedRepo) {
+        throw new Error(
+          'Unrecognized repository URL. Provide OWNER/REPO or a full git URL.',
+        );
+      }
+      owner = parsedRepo.owner;
+      repo = parsedRepo.repo;
     }
-    const { owner, repo } = parsedRepo;
 
     const comment_id = parseInt(commentIdArg, 10);
     if (isNaN(comment_id)) {

--- a/packages/gitcode-cli/src/commands/issue/edit.ts
+++ b/packages/gitcode-cli/src/commands/issue/edit.ts
@@ -7,10 +7,10 @@ import {
   colors,
   formatAssignees,
   resolveIssueContext,
-  type IssueTargetOptions,
+  type RepoOption,
 } from './helpers';
 
-interface EditOptions extends IssueTargetOptions {
+interface EditOptions extends RepoOption {
   title?: string;
   body?: string;
   bodyFile?: string;

--- a/packages/gitcode-cli/src/commands/issue/edit.ts
+++ b/packages/gitcode-cli/src/commands/issue/edit.ts
@@ -2,15 +2,9 @@ import type { UpdateIssueBody, UpdatedIssue } from '@gitany/gitcode';
 import { Command } from 'commander';
 import * as fs from 'fs';
 import { withClient } from '../../utils/with-client';
-import {
-  colorizeState,
-  colors,
-  formatAssignees,
-  resolveIssueContext,
-  type RepoOption,
-} from './helpers';
+import { colorizeState, colors, formatAssignees, resolveIssueContext } from './helpers';
 
-interface EditOptions extends RepoOption {
+interface EditOptions {
   title?: string;
   body?: string;
   bodyFile?: string;
@@ -38,7 +32,7 @@ export async function editAction(
 ) {
   await withClient(
     async (client) => {
-      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg, options);
+      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg);
 
       let finalBody = options.body;
       if (options.bodyFile) {
@@ -148,9 +142,5 @@ export function editCommand(): Command {
     )
     .option('--state <state>', 'Update issue state: open | closed')
     .option('--json', 'Output raw JSON instead of formatted text')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(editAction);
 }

--- a/packages/gitcode-cli/src/commands/issue/helpers.ts
+++ b/packages/gitcode-cli/src/commands/issue/helpers.ts
@@ -14,14 +14,14 @@ export const colors = {
   bright: '\x1b[1m',
 };
 
-export interface IssueTargetOptions {
+export interface RepoOption {
   repo?: string;
 }
 
 export async function resolveIssueContext(
   issueNumberArg: string,
   urlArg: string | undefined,
-  options: IssueTargetOptions = {},
+  options: RepoOption = {},
 ) {
   const issueNumber = Number(issueNumberArg);
   if (!Number.isFinite(issueNumber) || issueNumber <= 0) {

--- a/packages/gitcode-cli/src/commands/issue/helpers.ts
+++ b/packages/gitcode-cli/src/commands/issue/helpers.ts
@@ -1,5 +1,5 @@
 import { resolveRepoUrl } from '@gitany/git-lib';
-import { isObjectLike, type IssueUser } from '@gitany/gitcode';
+import { isObjectLike, parseGitUrl, type IssueUser } from '@gitany/gitcode';
 import { createLogger } from '@gitany/shared';
 
 const logger = createLogger('@xbghc/gitcode-cli');
@@ -17,15 +17,28 @@ export const colors = {
 export async function resolveIssueContext(
   issueNumberArg: string,
   urlArg: string | undefined,
-) {
+): Promise<{ issueNumber: number; repoUrl: string; owner: string; repo: string }> {
   const issueNumber = Number(issueNumberArg);
   if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
     logger.error('Invalid issue number');
     process.exit(1);
   }
 
-  const repoUrl = await resolveRepoUrl(urlArg);
-  return { issueNumber, repoUrl };
+  const resolved = await resolveRepoUrl(urlArg);
+  let owner = resolved.owner;
+  let repo = resolved.repo;
+
+  if (!owner || !repo) {
+    const parsed = parseGitUrl(resolved.repoUrl);
+    if (!parsed) {
+      logger.error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
+      process.exit(1);
+    }
+    owner = parsed.owner;
+    repo = parsed.repo;
+  }
+
+  return { issueNumber, repoUrl: resolved.repoUrl, owner, repo };
 }
 
 export function formatUserName(user: unknown): string {

--- a/packages/gitcode-cli/src/commands/issue/helpers.ts
+++ b/packages/gitcode-cli/src/commands/issue/helpers.ts
@@ -14,14 +14,9 @@ export const colors = {
   bright: '\x1b[1m',
 };
 
-export interface RepoOption {
-  repo?: string;
-}
-
 export async function resolveIssueContext(
   issueNumberArg: string,
   urlArg: string | undefined,
-  options: RepoOption = {},
 ) {
   const issueNumber = Number(issueNumberArg);
   if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
@@ -29,8 +24,7 @@ export async function resolveIssueContext(
     process.exit(1);
   }
 
-  const repoInput = options.repo ?? urlArg;
-  const repoUrl = await resolveRepoUrl(repoInput);
+  const repoUrl = await resolveRepoUrl(urlArg);
   return { issueNumber, repoUrl };
 }
 

--- a/packages/gitcode-cli/src/commands/issue/list.ts
+++ b/packages/gitcode-cli/src/commands/issue/list.ts
@@ -8,7 +8,8 @@ export async function listCommand(
 ): Promise<void> {
   await withClient(
     async (client) => {
-      const repoUrl = await resolveRepoUrl(url);
+      const resolved = await resolveRepoUrl(url);
+      const repoUrl = resolved.repoUrl;
       const issues: Issue[] = await client.issue.list(repoUrl, {
         state: options.state as 'open' | 'closed' | 'all' | undefined,
         labels: options.label,

--- a/packages/gitcode-cli/src/commands/issue/reopen.ts
+++ b/packages/gitcode-cli/src/commands/issue/reopen.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { withClient } from '../../utils/with-client';
-import { colorizeState, colors, resolveIssueContext, type IssueTargetOptions } from './helpers';
+import { colorizeState, colors, resolveIssueContext, type RepoOption } from './helpers';
 
-interface ReopenOptions extends IssueTargetOptions {
+interface ReopenOptions extends RepoOption {
   json?: boolean;
 }
 

--- a/packages/gitcode-cli/src/commands/issue/reopen.ts
+++ b/packages/gitcode-cli/src/commands/issue/reopen.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { withClient } from '../../utils/with-client';
-import { colorizeState, colors, resolveIssueContext, type RepoOption } from './helpers';
+import { colorizeState, colors, resolveIssueContext } from './helpers';
 
-interface ReopenOptions extends RepoOption {
+interface ReopenOptions {
   json?: boolean;
 }
 
@@ -13,7 +13,7 @@ export async function reopenAction(
 ) {
   await withClient(
     async (client) => {
-      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg, options);
+      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg);
 
       const issue = await client.issue.update(repoUrl, issueNumber, { state: 'open' });
 
@@ -46,9 +46,5 @@ export function reopenCommand(): Command {
     .argument('<number>', 'Issue number')
     .argument('[url]', 'Repository URL')
     .option('--json', 'Output raw JSON instead of formatted text')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(reopenAction);
 }

--- a/packages/gitcode-cli/src/commands/issue/status.ts
+++ b/packages/gitcode-cli/src/commands/issue/status.ts
@@ -2,10 +2,10 @@ import { Command } from 'commander';
 import { parseGitUrl } from '@gitany/gitcode';
 import { resolveRepoUrl } from '@gitany/git-lib';
 import { withClient } from '../../utils/with-client';
+import { type RepoOption } from './helpers';
 
-interface StatusOptions {
+interface StatusOptions extends RepoOption {
   json?: boolean;
-  repo?: string;
 }
 
 export async function statusAction(urlArg?: string, options: StatusOptions = {}) {

--- a/packages/gitcode-cli/src/commands/issue/status.ts
+++ b/packages/gitcode-cli/src/commands/issue/status.ts
@@ -9,16 +9,21 @@ interface StatusOptions {
 
 export async function statusAction(urlArg?: string, options: StatusOptions = {}) {
   await withClient(async (client) => {
-    const url = await resolveRepoUrl(urlArg);
-    const parsed = parseGitUrl(url);
-    if (!parsed) {
-      throw new Error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
+    const resolved = await resolveRepoUrl(urlArg);
+    let owner = resolved.owner;
+    let repo = resolved.repo;
+
+    if (!owner || !repo) {
+      const parsed = parseGitUrl(resolved.repoUrl);
+      if (!parsed) {
+        throw new Error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
+      }
+      owner = parsed.owner;
+      repo = parsed.repo;
     }
 
-    const { owner, repo } = parsed;
-
     // 获取 issues 统计信息
-    const repoUrl = `${owner}/${repo}`;
+    const repoUrl = resolved.repoUrl;
     const [openIssues, closedIssues, recentIssues] = await Promise.all([
       client.issue.list(repoUrl, { state: 'open', per_page: 100 }),
       client.issue.list(repoUrl, { state: 'closed', per_page: 100 }),

--- a/packages/gitcode-cli/src/commands/issue/status.ts
+++ b/packages/gitcode-cli/src/commands/issue/status.ts
@@ -2,53 +2,20 @@ import { Command } from 'commander';
 import { parseGitUrl } from '@gitany/gitcode';
 import { resolveRepoUrl } from '@gitany/git-lib';
 import { withClient } from '../../utils/with-client';
-import { type RepoOption } from './helpers';
 
-interface StatusOptions extends RepoOption {
+interface StatusOptions {
   json?: boolean;
 }
 
 export async function statusAction(urlArg?: string, options: StatusOptions = {}) {
   await withClient(async (client) => {
-    // 解析 repository URL
-    let owner: string;
-    let repo: string;
-
-    if (options.repo) {
-      const parsed = parseGitUrl(options.repo);
-      if (parsed) {
-        owner = parsed.owner;
-        repo = parsed.repo;
-      } else {
-        const parts = options.repo.split('/');
-        if (parts.length === 2) {
-          owner = parts[0];
-          repo = parts[1];
-        } else if (parts.length === 3) {
-          owner = parts[1];
-          repo = parts[2];
-        } else {
-          throw new Error('Invalid repository format. Use [HOST/]OWNER/REPO');
-        }
-      }
-    } else {
-      const url = await resolveRepoUrl(urlArg);
-      const parsed = parseGitUrl(url);
-      if (parsed) {
-        owner = parsed.owner;
-        repo = parsed.repo;
-      } else {
-        const parts = url.split('/');
-        if (parts.length === 2) {
-          owner = parts[0];
-          repo = parts[1];
-        } else {
-          throw new Error(
-            'Invalid repository format. Use OWNER/REPO or https://gitcode.com/OWNER/REPO',
-          );
-        }
-      }
+    const url = await resolveRepoUrl(urlArg);
+    const parsed = parseGitUrl(url);
+    if (!parsed) {
+      throw new Error('Unrecognized repository URL. Provide OWNER/REPO or a full git URL.');
     }
+
+    const { owner, repo } = parsed;
 
     // 获取 issues 统计信息
     const repoUrl = `${owner}/${repo}`;
@@ -118,7 +85,7 @@ export async function statusAction(urlArg?: string, options: StatusOptions = {})
       }
 
       console.log(`\n💡 Quick Actions:`);
-      console.log(`   • Create new issue:  gitcode issue create ${owner} ${repo} "Title"`);
+      console.log(`   • Create new issue:  gitcode issue create ${owner}/${repo} "Title"`);
       console.log(`   • List all issues:   gitcode issue list ${owner}/${repo}`);
       console.log(
         `   • View repository:   ${colors.blue}https://gitcode.com/${owner}/${repo}${colors.reset}`,
@@ -133,9 +100,5 @@ export function statusCommand(): Command {
     .description('Show issue status and statistics for a repository')
     .argument('[url]', 'Repository URL or OWNER/REPO')
     .option('--json', 'Output raw JSON instead of formatted status')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(statusAction);
 }

--- a/packages/gitcode-cli/src/commands/issue/view.ts
+++ b/packages/gitcode-cli/src/commands/issue/view.ts
@@ -8,10 +8,10 @@ import {
   colorizeState,
   formatUserName,
   resolveIssueContext,
-  type IssueTargetOptions,
+  type RepoOption,
 } from './helpers';
 
-interface ViewOptions extends IssueTargetOptions {
+interface ViewOptions extends RepoOption {
   comments?: boolean;
   page?: string;
   perPage?: string;

--- a/packages/gitcode-cli/src/commands/issue/view.ts
+++ b/packages/gitcode-cli/src/commands/issue/view.ts
@@ -3,15 +3,9 @@ import { withClient } from '../../utils/with-client';
 import { formatAssignees } from './helpers';
 import type { IssueComment, IssueDetail } from '@gitany/gitcode';
 import { isObjectLike } from '@gitany/gitcode';
-import {
-  colors,
-  colorizeState,
-  formatUserName,
-  resolveIssueContext,
-  type RepoOption,
-} from './helpers';
+import { colors, colorizeState, formatUserName, resolveIssueContext } from './helpers';
 
-interface ViewOptions extends RepoOption {
+interface ViewOptions {
   comments?: boolean;
   page?: string;
   perPage?: string;
@@ -25,7 +19,7 @@ export async function viewAction(
 ) {
   await withClient(
     async (client) => {
-      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg, options);
+      const { issueNumber, repoUrl } = await resolveIssueContext(issueNumberArg, urlArg);
 
       const issue: IssueDetail = await client.issue.get(repoUrl, issueNumber);
       let comments: IssueComment[] | undefined;
@@ -148,9 +142,5 @@ export function viewCommand(): Command {
     .option('--page <n>', 'Page number when fetching comments')
     .option('--per-page <n>', 'Items per page when fetching comments')
     .option('--json', 'Output raw JSON instead of formatted text')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(viewAction);
 }

--- a/packages/gitcode-cli/src/commands/pr/comments.ts
+++ b/packages/gitcode-cli/src/commands/pr/comments.ts
@@ -25,7 +25,8 @@ export async function prCommentsCommand(
 
   await withClient(
     async (client) => {
-      const repoUrl = await resolveRepoUrl(url);
+      const resolved = await resolveRepoUrl(url);
+      const repoUrl = resolved.repoUrl;
       const comments: PRComment[] = await client.pr.comments(repoUrl, n, {
         page: options.page ? Number(options.page) : undefined,
         per_page: options.perPage ? Number(options.perPage) : undefined,

--- a/packages/gitcode-cli/src/commands/pr/create-comment.ts
+++ b/packages/gitcode-cli/src/commands/pr/create-comment.ts
@@ -6,15 +6,15 @@ import { execSync } from 'child_process';
 import { resolveRepoUrl } from '@gitany/git-lib';
 import { withClient } from '../../utils/with-client';
 import { createLogger } from '@gitany/shared';
+import { type RepoOption } from '../issue/helpers';
 
 const logger = createLogger('@xbghc/gitcode-cli');
 
-interface CreatePrCommentOptions {
+interface CreatePrCommentOptions extends RepoOption {
   body?: string;
   bodyFile?: string;
   editor?: boolean;
   json?: boolean;
-  repo?: string;
 }
 
 // 获取默认编辑器

--- a/packages/gitcode-cli/src/commands/pr/create-comment.ts
+++ b/packages/gitcode-cli/src/commands/pr/create-comment.ts
@@ -6,11 +6,10 @@ import { execSync } from 'child_process';
 import { resolveRepoUrl } from '@gitany/git-lib';
 import { withClient } from '../../utils/with-client';
 import { createLogger } from '@gitany/shared';
-import { type RepoOption } from '../issue/helpers';
 
 const logger = createLogger('@xbghc/gitcode-cli');
 
-interface CreatePrCommentOptions extends RepoOption {
+interface CreatePrCommentOptions {
   body?: string;
   bodyFile?: string;
   editor?: boolean;
@@ -44,13 +43,14 @@ async function openEditor(content: string): Promise<string> {
 
 export async function createPrCommentAction(
   prNumber: string,
+  repoUrlArg: string | undefined,
   body: string,
   options: CreatePrCommentOptions = {},
 ) {
   let repoUrl = '';
   await withClient(
     async (client) => {
-      repoUrl = await resolveRepoUrl(options.repo);
+      repoUrl = await resolveRepoUrl(repoUrlArg);
 
       // 解析仓库URL获取 owner/repo（复用通用解析器）
       const parsed = parseGitUrl(repoUrl);
@@ -106,37 +106,23 @@ export function createPrCommentCommand(): Command {
     )
     .option('-e, --editor', 'Open text editor to write the comment')
     .option('--json', 'Output raw JSON instead of formatted output')
-    .option(
-      '-R, --repo <[HOST/]OWNER/REPO>',
-      'Select another repository using the [HOST/]OWNER/REPO format',
-    )
     .action(
-      async (prNumber: string, repoUrlArg: string | undefined, options: CreatePrCommentOptions) => {
-        const repoArg = repoUrlArg?.trim() || undefined;
-        const repoOption = options.repo?.trim() || undefined;
-
-        if (repoArg && repoOption && repoArg !== repoOption) {
-          throw new Error('Repository specified twice. Use either positional [url] or --repo.');
-        }
-
-        const resolvedOptions: CreatePrCommentOptions = {
-          ...options,
-          repo: repoArg ?? repoOption,
-        };
+      async (prNumber: string, repoUrlArg: string | undefined, options: CreatePrCommentOptions = {}) => {
+        const trimmedRepoArg = repoUrlArg?.trim() || undefined;
 
         // 获取评论内容
-        let finalBody = resolvedOptions.body || '';
+        let finalBody = options.body || '';
 
-        if (resolvedOptions.bodyFile) {
-          if (resolvedOptions.bodyFile === '-') {
+        if (options.bodyFile) {
+          if (options.bodyFile === '-') {
             finalBody = fs.readFileSync(0, 'utf-8').trim();
           } else {
-            if (!fs.existsSync(resolvedOptions.bodyFile)) {
-              throw new Error(`File not found: ${resolvedOptions.bodyFile}`);
+            if (!fs.existsSync(options.bodyFile)) {
+              throw new Error(`File not found: ${options.bodyFile}`);
             }
-            finalBody = fs.readFileSync(resolvedOptions.bodyFile, 'utf-8').trim();
+            finalBody = fs.readFileSync(options.bodyFile, 'utf-8').trim();
           }
-        } else if (resolvedOptions.editor) {
+        } else if (options.editor) {
           const template = `# Comment on Pull Request #${prNumber}
 
 <!-- Write your comment below -->`;
@@ -151,7 +137,7 @@ export function createPrCommentCommand(): Command {
           throw new Error('Comment body is required');
         }
 
-        await createPrCommentAction(prNumber, finalBody, resolvedOptions);
+        await createPrCommentAction(prNumber, trimmedRepoArg, finalBody, options);
       },
     );
 }

--- a/packages/gitcode-cli/src/commands/pr/create-comment.ts
+++ b/packages/gitcode-cli/src/commands/pr/create-comment.ts
@@ -50,20 +50,33 @@ export async function createPrCommentAction(
   let repoUrl = '';
   await withClient(
     async (client) => {
-      repoUrl = await resolveRepoUrl(repoUrlArg);
+      const resolved = await resolveRepoUrl(repoUrlArg);
+      repoUrl = resolved.repoUrl;
 
-      // 解析仓库URL获取 owner/repo（复用通用解析器）
-      const parsed = parseGitUrl(repoUrl);
-      if (!parsed) {
-        throw new Error(
-          'Unrecognized repository URL. Provide a full git URL or run inside a git repo.',
-        );
+      if (!resolved.owner || !resolved.repo) {
+        const parsed = parseGitUrl(repoUrl);
+        if (!parsed) {
+          throw new Error(
+            'Unrecognized repository URL. Provide a full git URL or run inside a git repo.',
+          );
+        }
       }
 
-      const prNum = parseInt(prNumber, 10);
+      let prNum = Number.parseInt(prNumber, 10);
+      const resourcePrNumber = resolved.resource?.type === 'pull' ? resolved.resource.number : undefined;
 
-      if (isNaN(prNum)) {
+      if (Number.isNaN(prNum)) {
+        if (resourcePrNumber !== undefined) {
+          prNum = resourcePrNumber;
+        }
+      }
+
+      if (Number.isNaN(prNum)) {
         throw new Error('Invalid PR number');
+      }
+
+      if (resourcePrNumber !== undefined && prNum !== resourcePrNumber) {
+        throw new Error('PR number mismatch between argument and repository reference');
       }
 
       const comment = await client.pr.createComment(repoUrl, prNum, body);

--- a/packages/gitcode-cli/src/commands/pr/create.ts
+++ b/packages/gitcode-cli/src/commands/pr/create.ts
@@ -27,7 +27,8 @@ export async function createCommand(
   }
 
   await withClient(async (client) => {
-    const repoUrl = await resolveRepoUrl(url);
+    const resolved = await resolveRepoUrl(url);
+    const repoUrl = resolved.repoUrl;
     const created = await client.pr.create(repoUrl, body);
 
     const pr = created;

--- a/packages/gitcode-cli/src/commands/pr/list.ts
+++ b/packages/gitcode-cli/src/commands/pr/list.ts
@@ -8,7 +8,8 @@ export async function listCommand(
 ): Promise<void> {
   await withClient(
     async (client) => {
-      const repoUrl = await resolveRepoUrl(url);
+      const resolved = await resolveRepoUrl(url);
+      const repoUrl = resolved.repoUrl;
       const pulls: PullRequest[] = await client.pr.list(repoUrl, {
         state: options.state,
         head: options.head,

--- a/packages/gitcode-cli/src/commands/repo/permission.ts
+++ b/packages/gitcode-cli/src/commands/repo/permission.ts
@@ -3,7 +3,8 @@ import { withClient } from '../../utils/with-client';
 
 export async function permissionCommand(url?: string): Promise<void> {
   await withClient(async (client) => {
-    const repoUrl = await resolveRepoUrl(url);
+    const resolved = await resolveRepoUrl(url);
+    const repoUrl = resolved.repoUrl;
     const permission = await client.repo.getSelfRepoPermissionRole(repoUrl);
     console.log(`Repository permission: ${permission}`);
   }, 'Failed to get repo permission');

--- a/packages/gitcode-cli/src/index.ts
+++ b/packages/gitcode-cli/src/index.ts
@@ -52,13 +52,29 @@ program
   .description('Parse Git URL and output JSON')
   .action(async (url?: string) => {
     try {
-      const repoUrl = await resolveRepoUrl(url);
-      const parsed = parseGitUrl(repoUrl);
+      const resolved = await resolveRepoUrl(url);
+      const repoUrl = resolved.repoUrl;
+      const parsed =
+        resolved.owner && resolved.repo
+          ? { owner: resolved.owner, repo: resolved.repo, host: resolved.host }
+          : parseGitUrl(repoUrl);
       if (!parsed) {
         logger.error({ url: repoUrl }, 'Unrecognized git URL');
         process.exit(1);
       }
-      console.log(JSON.stringify(parsed, null, 2));
+      console.log(
+        JSON.stringify(
+          {
+            repoUrl,
+            owner: parsed.owner,
+            repo: parsed.repo,
+            host: parsed.host,
+            resource: resolved.resource ?? null,
+          },
+          null,
+          2,
+        ),
+      );
     } catch (err) {
       logger.error({ err }, 'Failed to parse git URL');
       process.exit(1);

--- a/packages/gitcode/package.json
+++ b/packages/gitcode/package.json
@@ -27,6 +27,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@gitany/git-lib": "workspace:*",
     "@gitany/shared": "workspace:*",
     "got": "^14.4.9",
     "zod": "^4.1.7"

--- a/packages/gitcode/src/utils/index.ts
+++ b/packages/gitcode/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { parseRepoUrl } from '@gitany/git-lib';
+
 export type Remote = { owner: string; repo: string; host?: string };
 /**
  * Parses a Git remote URL like:
@@ -6,18 +8,15 @@ export type Remote = { owner: string; repo: string; host?: string };
  */
 
 export function parseGitUrl(url: string): Remote | null {
-  // Simple, safe parsing — returns null on unknown shapes.
-  const https = url.match(/^https?:\/\/([^/]+)\/([^/]+)\/([^/.]+)(?:\.git)?$/);
-  if (https) {
-    return { host: https[1], owner: https[2], repo: https[3] };
+  try {
+    const resolved = parseRepoUrl(url);
+    if (!resolved.owner || !resolved.repo) {
+      return null;
+    }
+    return { host: resolved.host, owner: resolved.owner, repo: resolved.repo };
+  } catch {
+    return null;
   }
-
-  const ssh = url.match(/^git@([^:]+):([^/]+)\/([^/.]+)(?:\.git)?$/);
-  if (ssh) {
-    return { host: ssh[1], owner: ssh[2], repo: ssh[3] };
-  }
-
-  return null;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
 
   packages/gitcode:
     dependencies:
+      '@gitany/git-lib':
+        specifier: workspace:*
+        version: link:../git-lib
       '@gitany/shared':
         specifier: workspace:*
         version: link:../shared
@@ -698,67 +701,56 @@ packages:
     resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.0':
     resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.0':
     resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.0':
     resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
     resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.0':
     resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.0':
     resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.0':
     resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.0':
     resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.0':
     resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.0':
     resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.0':
     resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}


### PR DESCRIPTION
## Summary
- rename the issue helper option type to RepoOption for reuse across commands
- extend every CLI command supporting -R/--repo to use the shared RepoOption type

## Testing
- pnpm --filter @xbghc/gitcode-cli lint

------
https://chatgpt.com/codex/tasks/task_e_68df19360d8483268fc6f5426ec95b34