### PR TITLE
Use simple-git for git remotes

### DIFF
--- a/packages/gitcode-cli/package.json
+++ b/packages/gitcode-cli/package.json
@@ -48,7 +48,8 @@
     "@inquirer/prompts": "^7.10.0",
     "@xbghc/gitcode-api": "workspace:*",
     "commander": "^14.0.0",
-    "open": "^10.1.0"
+    "open": "^10.1.0",
+    "simple-git": "^3.30.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/gitcode-cli/src/commands/status.ts
+++ b/packages/gitcode-cli/src/commands/status.ts
@@ -1,10 +1,12 @@
 import { withClient } from '../utils/with-client.js';
-import { parseGitRemotes, type GitRemote } from '../utils/parse-git-remotes.js';
+import { parseGitRemotes } from '../utils/parse-git-remotes.js';
 import type { UserProfile } from '@xbghc/gitcode-api';
 
 interface StatusOptions {
   json?: boolean;
 }
+
+type GitRemote = Awaited<ReturnType<typeof parseGitRemotes>>[number];
 
 interface StatusOutput {
   user: {
@@ -23,7 +25,7 @@ export async function statusCommand(options: StatusOptions = {}): Promise<void> 
     const userProfile: UserProfile = await client.user.getProfile();
 
     // Try to get git remotes (will be empty if not in a git repo)
-    const remotes = parseGitRemotes();
+    const remotes = await parseGitRemotes();
 
     if (options.json) {
       // JSON output

--- a/packages/gitcode-cli/src/utils/parse-git-remotes.ts
+++ b/packages/gitcode-cli/src/utils/parse-git-remotes.ts
@@ -1,4 +1,4 @@
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 /**
  * Check if a URL belongs to GitCode platform

--- a/packages/gitcode-cli/src/utils/parse-git-remotes.ts
+++ b/packages/gitcode-cli/src/utils/parse-git-remotes.ts
@@ -1,12 +1,4 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
-export interface GitRemote {
-  name: string;
-  url: string;
-  fetch?: string;
-  isGitCode: boolean;
-}
+import simpleGit from 'simple-git';
 
 /**
  * Check if a URL belongs to GitCode platform
@@ -18,73 +10,40 @@ export function isGitCodeUrl(url: string): boolean {
 }
 
 /**
- * Parse .git/config file and extract all remote configurations
+ * Parse git remotes via simple-git
  * @param cwd - Current working directory (defaults to process.cwd())
  * @returns Array of git remotes with name, url, and optional fetch config
  */
-export function parseGitRemotes(cwd: string = process.cwd()): GitRemote[] {
-  const gitConfigPath = path.join(cwd, '.git', 'config');
+export async function parseGitRemotes(
+  cwd: string = process.cwd(),
+): Promise<Array<{ name: string; url: string; fetch?: string; isGitCode: boolean }>> {
+  try {
+    const git = simpleGit({ baseDir: cwd });
+    const isRepo = await git.checkIsRepo();
+    if (!isRepo) {
+      return [];
+    }
 
-  // If not in a git repository, return empty array
-  if (!fs.existsSync(gitConfigPath)) {
+    const remotes = await git.getRemotes(true);
+    return remotes.reduce<Array<{ name: string; url: string; fetch?: string; isGitCode: boolean }>>(
+      (parsed, remote) => {
+        const url = remote.refs.fetch || remote.refs.push;
+
+        if (url) {
+          parsed.push({
+            name: remote.name,
+            url,
+            fetch: remote.refs.fetch,
+            isGitCode: isGitCodeUrl(url),
+          });
+        }
+
+        return parsed;
+      },
+      [],
+    );
+  } catch {
+    // If git commands fail (e.g., not a repo), return empty
     return [];
   }
-
-  const content = fs.readFileSync(gitConfigPath, 'utf-8');
-  const lines = content.split('\n');
-
-  const remotes: GitRemote[] = [];
-  let currentRemote: Partial<GitRemote> | null = null;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Check for [remote "name"] section
-    const remoteMatch =
-      trimmed.match(/^\[remote\s+"([^"]+)"\]$/) || trimmed.match(/^\[remote\s+'([^']+)'\]$/);
-    if (remoteMatch) {
-      // Save previous remote if exists
-      if (currentRemote && currentRemote.name && currentRemote.url) {
-        remotes.push(currentRemote as GitRemote);
-      }
-      // Start new remote
-      currentRemote = { name: remoteMatch[1] };
-      continue;
-    }
-
-    // If we hit another section, save current remote and reset
-    if (trimmed.startsWith('[') && currentRemote) {
-      if (currentRemote.name && currentRemote.url) {
-        remotes.push(currentRemote as GitRemote);
-      }
-      currentRemote = null;
-      continue;
-    }
-
-    // Extract url and fetch from current remote section
-    if (currentRemote) {
-      const urlMatch = trimmed.match(/^url\s*=\s*(.+)$/);
-      if (urlMatch) {
-        currentRemote.url = urlMatch[1].trim();
-        continue;
-      }
-
-      const fetchMatch = trimmed.match(/^fetch\s*=\s*(.+)$/);
-      if (fetchMatch) {
-        currentRemote.fetch = fetchMatch[1].trim();
-        continue;
-      }
-    }
-  }
-
-  // Don't forget the last remote
-  if (currentRemote && currentRemote.name && currentRemote.url) {
-    remotes.push(currentRemote as GitRemote);
-  }
-
-  // Add isGitCode field to all remotes
-  return remotes.map((remote) => ({
-    ...remote,
-    isGitCode: isGitCodeUrl(remote.url),
-  }));
 }

--- a/packages/gitcode-cli/src/utils/resolve-repo-url.ts
+++ b/packages/gitcode-cli/src/utils/resolve-repo-url.ts
@@ -1,4 +1,4 @@
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 
 /**
  * Normalize repository URL input

--- a/packages/gitcode-cli/src/utils/resolve-repo-url.ts
+++ b/packages/gitcode-cli/src/utils/resolve-repo-url.ts
@@ -1,78 +1,4 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
-/**
- * Parse .git/config file and extract remote origin URL
- */
-function resolveGitDir(cwd: string): string {
-  const gitPath = path.join(cwd, '.git');
-
-  if (!fs.existsSync(gitPath)) {
-    throw new Error('Not a git repository (or any of the parent directories)');
-  }
-
-  const stat = fs.lstatSync(gitPath);
-  if (stat.isDirectory()) {
-    return gitPath;
-  }
-
-  if (stat.isSymbolicLink()) {
-    return fs.realpathSync(gitPath);
-  }
-
-  if (stat.isFile()) {
-    const content = fs.readFileSync(gitPath, 'utf-8');
-    const match = content.match(/^gitdir:\s*(.+)$/m);
-    if (!match) {
-      throw new Error('Invalid gitdir reference in .git file');
-    }
-
-    const gitDirPath = match[1].trim();
-    return path.isAbsolute(gitDirPath) ? gitDirPath : path.resolve(cwd, gitDirPath);
-  }
-
-  throw new Error('Unsupported .git entry');
-}
-
-function parseGitConfig(cwd: string = process.cwd()): string {
-  const gitDir = resolveGitDir(cwd);
-  const gitConfigPath = path.join(gitDir, 'config');
-
-  if (!fs.existsSync(gitConfigPath)) {
-    throw new Error(
-      'Not a git repository (or any of the parent directories): .git/config not found',
-    );
-  }
-
-  const content = fs.readFileSync(gitConfigPath, 'utf-8');
-  const lines = content.split('\n');
-
-  let inRemoteOrigin = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Check for [remote "origin"] section
-    if (trimmed === '[remote "origin"]' || trimmed === "[remote 'origin']") {
-      inRemoteOrigin = true;
-      continue;
-    }
-
-    // Exit remote origin section if we hit another section
-    if (trimmed.startsWith('[') && inRemoteOrigin) {
-      break;
-    }
-
-    // Extract url from remote origin section
-    if (inRemoteOrigin && trimmed.startsWith('url')) {
-      const match = trimmed.match(/url\s*=\s*(.+)/);
-      if (match) {
-        return match[1].trim();
-      }
-    }
-  }
-
-  throw new Error('No remote origin URL found in git config');
-}
+import simpleGit from 'simple-git';
 
 /**
  * Normalize repository URL input
@@ -119,5 +45,27 @@ export async function resolveRepoUrl(
   }
 
   const cwd = options.cwd || process.cwd();
-  return parseGitConfig(cwd);
+  try {
+    const git = simpleGit({ baseDir: cwd });
+    const isRepo = await git.checkIsRepo();
+    if (!isRepo) {
+      throw new Error('Not a git repository (or any of the parent directories)');
+    }
+
+    const remotes = await git.getRemotes(true);
+    const origin = remotes.find((remote) => remote.name === 'origin');
+    const originUrl = origin?.refs.fetch || origin?.refs.push;
+
+    if (!originUrl) {
+      throw new Error('No remote origin URL found in git config');
+    }
+
+    return originUrl;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error('Failed to resolve repository URL');
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.2.0
+      simple-git:
+        specifier: ^3.30.0
+        version: 3.30.0
     devDependencies:
       esbuild:
         specifier: ^0.21.5
@@ -1581,6 +1584,18 @@ packages:
     resolution:
       {
         integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==,
+      }
+
+  '@kwsites/file-exists@1.1.1':
+    resolution:
+      {
+        integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==,
+      }
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution:
+      {
+        integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==,
       }
 
   '@manypkg/find-root@1.1.0':
@@ -5333,6 +5348,12 @@ packages:
       }
     engines: { node: '>=14' }
 
+  simple-git@3.30.0:
+    resolution:
+      {
+        integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==,
+      }
+
   sirv@3.0.2:
     resolution:
       {
@@ -6855,7 +6876,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6869,7 +6890,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -7085,6 +7106,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7424,7 +7453,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.42.0
-      debug: 4.4.1
+      debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -7443,7 +7472,7 @@ snapshots:
       '@typescript-eslint/types': 8.42.0
       '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.9.2)
       '@typescript-eslint/utils': 8.42.0(eslint@9.34.0)(typescript@5.9.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.34.0
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -7458,7 +7487,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.42.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.42.0
       '@typescript-eslint/visitor-keys': 8.42.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8126,7 +8155,7 @@ snapshots:
 
   docker-modem@5.0.6:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
@@ -9347,6 +9376,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git@3.30.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   sirv@3.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- add `simple-git` as a dependency for the CLI and use it to enumerate remotes
- switch git remote parsing to `simple-git` and update status output to handle the async flow
- reuse `simple-git` to resolve the origin URL instead of manual `.git/config` parsing
- derive the remote type from the parser output instead of exporting a standalone interface

## Testing
- pnpm --filter @xbghc/gitcode-cli lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203d94960483268b0811e60bbfa8a7)