### PR TITLE
Fix dashboard tab layout scrolling

### DIFF
--- a/packages/gitcode-dashboard/src/layouts/MainLayout.vue
+++ b/packages/gitcode-dashboard/src/layouts/MainLayout.vue
@@ -119,7 +119,7 @@ onMounted(() => {
 .app-main {
   background-color: #f5f5f5;
   padding: 0;
-  overflow-y: auto;
+  overflow: hidden;
   height: 100%;
 }
 
@@ -136,6 +136,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   background-color: #fff;
+  overflow: hidden;
 }
 
 .repo-header {
@@ -177,6 +178,12 @@ onMounted(() => {
   padding: 24px;
   display: flex;
   flex-direction: column;
+}
+
+.content-tabs :deep(.el-tab-pane) {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .fade-enter-active,

--- a/packages/gitcode-dashboard/src/views/activity/ActivityList.vue
+++ b/packages/gitcode-dashboard/src/views/activity/ActivityList.vue
@@ -28,7 +28,7 @@
     </div>
 
     <!-- 活动时间轴 -->
-    <div v-loading="activityStore.loading" class="timeline-wrapper">
+    <div ref="timelineRef" v-loading="activityStore.loading" class="timeline-wrapper">
       <el-empty
         v-if="!activityStore.loading && activityStore.activityList.length === 0"
         description="暂无活动"
@@ -123,9 +123,11 @@ const handleFilterChange = (filter: string) => {
   activityStore.updateFilters({ filter: filter as any, page: 1 });
 };
 
+const timelineRef = ref<HTMLElement | null>(null);
+
 // 无限滚动
 useInfiniteScroll(
-  () => document.querySelector('.app-main') as HTMLElement | null,
+  timelineRef,
   () => {
     if (!activityStore.loadingMore && activityStore.hasMore) {
       activityStore.loadMore();


### PR DESCRIPTION
## Summary
- hide overflow on the main dashboard container and tab content to prevent global scrolling
- stretch tab panes to full height so the activity timeline wrapper owns the scrollbar for infinite scroll

## Testing
- pnpm --filter @xbghc/gitcode-dashboard build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69212cfeae688326b657b42ff487517b)