### PR TITLE
fix: Replace Zod parse with safeParse for error handling

### DIFF
--- a/packages/gitcode-api/src/__tests__/unit/client/parser.test.ts
+++ b/packages/gitcode-api/src/__tests__/unit/client/parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
-import { parseApiResponse } from '../../../client/parser.js';
+import { parseApiResponse, safeParseApiResponse } from '../../../client/parser.js';
 import { ApiValidationError } from '../../../client/errors.js';
 import {
   simpleSchema,
@@ -330,6 +330,201 @@ describe('parseApiResponse', () => {
             endpoint: 'test/endpoint',
           },
         ),
+      ).toThrow(ApiValidationError);
+    });
+  });
+});
+
+describe('safeParseApiResponse', () => {
+  describe('成功解析', () => {
+    it('应该返回 success: true 和验证后的数据', () => {
+      const result = safeParseApiResponse(simpleSchema, validSimpleData, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validSimpleData);
+      }
+    });
+
+    it('应该返回正确的类型（类型守卫测试）', () => {
+      const result = safeParseApiResponse(simpleSchema, validSimpleData, {
+        endpoint: 'test/endpoint',
+      });
+
+      if (result.success) {
+        // TypeScript 应该推断出 result.data 的类型
+        const id: number = result.data.id;
+        const name: string = result.data.name;
+        expect(typeof id).toBe('number');
+        expect(typeof name).toBe('string');
+      } else {
+        expect.fail('Expected success');
+      }
+    });
+
+    it('应该处理复杂嵌套对象', () => {
+      const result = safeParseApiResponse(nestedSchema, validNestedData, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validNestedData);
+      }
+    });
+
+    it('应该处理数组类型', () => {
+      const arraySchema = z.array(simpleSchema);
+      const arrayData = [validSimpleData, { ...validSimpleData, id: 2, name: 'Test 2' }];
+
+      const result = safeParseApiResponse(arraySchema, arrayData, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(arrayData);
+        expect(result.data).toHaveLength(2);
+      }
+    });
+  });
+
+  describe('验证失败', () => {
+    it('应该返回 success: false 和 ApiValidationError（不抛出异常）', () => {
+      const result = safeParseApiResponse(simpleSchema, invalidSimpleData_wrongIdType, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ApiValidationError);
+      }
+    });
+
+    it('应该在必需字段缺失时返回失败结果', () => {
+      const result = safeParseApiResponse(simpleSchema, invalidSimpleData_missingName, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ApiValidationError);
+      }
+    });
+
+    it('错误应该包含正确的上下文信息', () => {
+      const result = safeParseApiResponse(simpleSchema, invalidSimpleData_wrongIdType, {
+        endpoint: 'repos/owner/repo/pulls',
+        method: 'GET',
+        params: { state: 'open' },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.context.endpoint).toBe('repos/owner/repo/pulls');
+        expect(result.error.context.method).toBe('GET');
+        expect(result.error.context.params).toEqual({ state: 'open' });
+      }
+    });
+
+    it('错误应该包含原始数据用于调试', () => {
+      const result = safeParseApiResponse(simpleSchema, invalidSimpleData_wrongIdType, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.context.data).toEqual(invalidSimpleData_wrongIdType);
+      }
+    });
+
+    it('应该能通过错误方法获取详细信息', () => {
+      const result = safeParseApiResponse(simpleSchema, invalidSimpleData_wrongIdType, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(typeof result.error.getSummary()).toBe('string');
+        expect(typeof result.error.getIssues).toBe('function');
+        expect(typeof result.error.getFieldErrors).toBe('function');
+      }
+    });
+  });
+
+  describe('边界情况', () => {
+    it('应该处理 null 数据', () => {
+      const nullableSchema = z.null();
+
+      const result = safeParseApiResponse(nullableSchema, null, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+    });
+
+    it('应该拒绝意外的 null 数据', () => {
+      const result = safeParseApiResponse(simpleSchema, null, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('应该拒绝 undefined 数据', () => {
+      const result = safeParseApiResponse(simpleSchema, undefined, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('应该处理空数组', () => {
+      const arraySchema = z.array(simpleSchema);
+
+      const result = safeParseApiResponse(arraySchema, [], {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual([]);
+      }
+    });
+  });
+
+  describe('与 parseApiResponse 的一致性', () => {
+    it('成功时两者应该返回相同的数据', () => {
+      const safeResult = safeParseApiResponse(simpleSchema, validSimpleData, {
+        endpoint: 'test/endpoint',
+      });
+      const directResult = parseApiResponse(simpleSchema, validSimpleData, {
+        endpoint: 'test/endpoint',
+      });
+
+      expect(safeResult.success).toBe(true);
+      if (safeResult.success) {
+        expect(safeResult.data).toEqual(directResult);
+      }
+    });
+
+    it('失败时 safeParseApiResponse 不应抛出异常', () => {
+      // safeParseApiResponse 不应该抛出异常
+      const safeResult = safeParseApiResponse(simpleSchema, invalidSimpleData_wrongIdType, {
+        endpoint: 'test/endpoint',
+      });
+      expect(safeResult.success).toBe(false);
+
+      // parseApiResponse 应该抛出异常
+      expect(() =>
+        parseApiResponse(simpleSchema, invalidSimpleData_wrongIdType, {
+          endpoint: 'test/endpoint',
+        }),
       ).toThrow(ApiValidationError);
     });
   });

--- a/packages/gitcode-api/src/__tests__/unit/client/safe-call.test.ts
+++ b/packages/gitcode-api/src/__tests__/unit/client/safe-call.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vitest';
+import { safeCall, isSuccess, isFailure, type SafeCallResult } from '../../../client/safe-call.js';
+import { ApiValidationError } from '../../../client/errors.js';
+import { z } from 'zod';
+
+describe('safeCall', () => {
+  describe('成功调用', () => {
+    it('应该返回 success: true 和数据', async () => {
+      const result = await safeCall(async () => {
+        return { id: 1, name: 'test' };
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ id: 1, name: 'test' });
+      }
+    });
+
+    it('应该处理异步函数', async () => {
+      const result = await safeCall(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return 'async result';
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe('async result');
+      }
+    });
+
+    it('应该处理返回 null 的函数', async () => {
+      const result = await safeCall(async () => null);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeNull();
+      }
+    });
+
+    it('应该处理返回 undefined 的函数', async () => {
+      const result = await safeCall(async () => undefined);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeUndefined();
+      }
+    });
+  });
+
+  describe('验证错误', () => {
+    it('应该捕获 ApiValidationError 并返回 validation 类型', async () => {
+      const schema = z.object({ id: z.number() });
+      const zodError = schema.safeParse({ id: 'not a number' });
+
+      const result = await safeCall(async () => {
+        if (!zodError.success) {
+          throw new ApiValidationError(zodError.error, {
+            endpoint: '/test',
+            method: 'GET',
+          });
+        }
+        return zodError.data;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('validation');
+        expect(result.error.validationError).toBeInstanceOf(ApiValidationError);
+        expect(result.error.message).toBeDefined();
+      }
+    });
+
+    it('验证错误应该包含详细信息', async () => {
+      const schema = z.object({
+        user: z.object({
+          name: z.string(),
+        }),
+      });
+      const zodError = schema.safeParse({ user: { name: 123 } });
+
+      const result = await safeCall(async () => {
+        if (!zodError.success) {
+          throw new ApiValidationError(zodError.error, {
+            endpoint: '/api/users',
+            method: 'GET',
+          });
+        }
+        return zodError.data;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('validation');
+        expect(result.error.validationError?.context.endpoint).toBe('/api/users');
+      }
+    });
+  });
+
+  describe('HTTP 错误', () => {
+    it('应该捕获 HTTP 错误并返回 http 类型', async () => {
+      const httpError = Object.assign(new Error('Not Found'), {
+        response: { statusCode: 404 },
+      });
+
+      const result = await safeCall(async () => {
+        throw httpError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('http');
+        expect(result.error.statusCode).toBe(404);
+      }
+    });
+
+    it('应该处理 401 未授权错误', async () => {
+      const httpError = Object.assign(new Error('Unauthorized'), {
+        response: { statusCode: 401 },
+      });
+
+      const result = await safeCall(async () => {
+        throw httpError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('http');
+        expect(result.error.statusCode).toBe(401);
+      }
+    });
+
+    it('应该处理 429 限流错误', async () => {
+      const httpError = Object.assign(new Error('Too Many Requests'), {
+        response: { statusCode: 429 },
+      });
+
+      const result = await safeCall(async () => {
+        throw httpError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('http');
+        expect(result.error.statusCode).toBe(429);
+      }
+    });
+
+    it('应该处理 500 服务器错误', async () => {
+      const httpError = Object.assign(new Error('Internal Server Error'), {
+        response: { statusCode: 500 },
+      });
+
+      const result = await safeCall(async () => {
+        throw httpError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('http');
+        expect(result.error.statusCode).toBe(500);
+      }
+    });
+  });
+
+  describe('网络错误', () => {
+    it('应该捕获 ECONNREFUSED 错误', async () => {
+      const networkError = Object.assign(new Error('connect ECONNREFUSED'), {
+        code: 'ECONNREFUSED',
+      });
+
+      const result = await safeCall(async () => {
+        throw networkError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('network');
+        expect(result.error.message).toContain('ECONNREFUSED');
+      }
+    });
+
+    it('应该捕获 ETIMEDOUT 错误', async () => {
+      const networkError = Object.assign(new Error('connect ETIMEDOUT'), {
+        code: 'ETIMEDOUT',
+      });
+
+      const result = await safeCall(async () => {
+        throw networkError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('network');
+        expect(result.error.message).toContain('ETIMEDOUT');
+      }
+    });
+
+    it('应该捕获 ENOTFOUND 错误', async () => {
+      const networkError = Object.assign(new Error('getaddrinfo ENOTFOUND'), {
+        code: 'ENOTFOUND',
+      });
+
+      const result = await safeCall(async () => {
+        throw networkError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('network');
+        expect(result.error.message).toContain('ENOTFOUND');
+      }
+    });
+  });
+
+  describe('未知错误', () => {
+    it('应该捕获普通 Error', async () => {
+      const result = await safeCall(async () => {
+        throw new Error('Something went wrong');
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('unknown');
+        expect(result.error.message).toBe('Something went wrong');
+      }
+    });
+
+    it('应该捕获非 Error 类型的抛出', async () => {
+      const result = await safeCall(async () => {
+        throw 'string error';
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('unknown');
+        expect(result.error.message).toBe('string error');
+      }
+    });
+
+    it('应该捕获数字类型的抛出', async () => {
+      const result = await safeCall(async () => {
+        throw 42;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.type).toBe('unknown');
+        expect(result.error.message).toBe('42');
+      }
+    });
+  });
+
+  describe('错误对象应该保留原始 cause', () => {
+    it('验证错误应该保留原始 ApiValidationError', async () => {
+      const schema = z.object({ id: z.number() });
+      const zodError = schema.safeParse({ id: 'invalid' });
+      const originalError = new ApiValidationError(zodError.error!, {
+        endpoint: '/test',
+      });
+
+      const result = await safeCall(async () => {
+        throw originalError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.cause).toBe(originalError);
+      }
+    });
+
+    it('HTTP 错误应该保留原始错误', async () => {
+      const originalError = Object.assign(new Error('Not Found'), {
+        response: { statusCode: 404 },
+      });
+
+      const result = await safeCall(async () => {
+        throw originalError;
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.cause).toBe(originalError);
+      }
+    });
+  });
+});
+
+describe('isSuccess', () => {
+  it('应该正确识别成功结果', () => {
+    const successResult: SafeCallResult<number> = { success: true, data: 42 };
+    expect(isSuccess(successResult)).toBe(true);
+  });
+
+  it('应该正确识别失败结果', () => {
+    const failureResult: SafeCallResult<number> = {
+      success: false,
+      error: {
+        type: 'unknown',
+        message: 'error',
+        cause: new Error('error'),
+      },
+    };
+    expect(isSuccess(failureResult)).toBe(false);
+  });
+
+  it('作为类型守卫应该工作', () => {
+    const result: SafeCallResult<{ name: string }> = { success: true, data: { name: 'test' } };
+
+    if (isSuccess(result)) {
+      // TypeScript 应该知道 result.data 是 { name: string }
+      const name: string = result.data.name;
+      expect(name).toBe('test');
+    }
+  });
+});
+
+describe('isFailure', () => {
+  it('应该正确识别失败结果', () => {
+    const failureResult: SafeCallResult<number> = {
+      success: false,
+      error: {
+        type: 'unknown',
+        message: 'error',
+        cause: new Error('error'),
+      },
+    };
+    expect(isFailure(failureResult)).toBe(true);
+  });
+
+  it('应该正确识别成功结果', () => {
+    const successResult: SafeCallResult<number> = { success: true, data: 42 };
+    expect(isFailure(successResult)).toBe(false);
+  });
+
+  it('作为类型守卫应该工作', () => {
+    const result: SafeCallResult<number> = {
+      success: false,
+      error: {
+        type: 'validation',
+        message: 'validation error',
+        cause: new Error('error'),
+      },
+    };
+
+    if (isFailure(result)) {
+      // TypeScript 应该知道 result.error 存在
+      expect(result.error.type).toBe('validation');
+    }
+  });
+});

--- a/packages/gitcode-api/src/client/parser.ts
+++ b/packages/gitcode-api/src/client/parser.ts
@@ -2,9 +2,62 @@ import { z } from 'zod';
 import { ApiValidationError, type ApiValidationContext } from './errors.js';
 
 /**
+ * API 解析结果类型
+ */
+export type ApiParseResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: ApiValidationError };
+
+/**
+ * 安全解析 API 响应，返回 Result 类型而不是抛出异常
+ *
+ * 这个函数使用 Zod 的 safeParse，并将结果包装为统一的 Result 类型，
+ * 避免验证失败时程序崩溃。
+ *
+ * @param schema - Zod schema 定义
+ * @param data - 要验证的数据（通常是 API 响应）
+ * @param context - API 请求上下文信息
+ * @returns Result 类型，包含成功的数据或失败的错误信息
+ *
+ * @example
+ * ```typescript
+ * const json = await client.http.get(url).json();
+ * const result = safeParseApiResponse(pullRequestSchema, json, {
+ *   endpoint: url,
+ *   method: 'GET',
+ *   params: { state: 'open' },
+ * });
+ *
+ * if (result.success) {
+ *   console.log(result.data);
+ * } else {
+ *   console.error(result.error.getSummary());
+ * }
+ * ```
+ */
+export function safeParseApiResponse<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  context: ApiValidationContext,
+): ApiParseResult<T> {
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    const error = new ApiValidationError(result.error, {
+      ...context,
+      data,
+    });
+    return { success: false, error };
+  }
+
+  return { success: true, data: result.data };
+}
+
+/**
  * 安全解析 API 响应，失败时抛出友好的 ApiValidationError
  *
  * 这个函数替代了直接使用 `schema.parse()`，提供更好的错误消息和上下文信息。
+ * 注意：此函数在验证失败时会抛出异常，如果不希望抛出异常，请使用 `safeParseApiResponse`。
  *
  * @param schema - Zod schema 定义
  * @param data - 要验证的数据（通常是 API 响应）
@@ -27,14 +80,10 @@ export function parseApiResponse<T>(
   data: unknown,
   context: ApiValidationContext,
 ): T {
-  const result = schema.safeParse(data);
+  const result = safeParseApiResponse(schema, data, context);
 
   if (!result.success) {
-    // 将原始数据添加到 context 中，以便在错误消息中显示实际值
-    throw new ApiValidationError(result.error, {
-      ...context,
-      data,
-    });
+    throw result.error;
   }
 
   return result.data;

--- a/packages/gitcode-api/src/client/safe-call.ts
+++ b/packages/gitcode-api/src/client/safe-call.ts
@@ -1,0 +1,152 @@
+import { ApiValidationError } from './errors.js';
+import { isHttpError, type HttpError } from './http-error.js';
+
+/**
+ * API 调用结果类型
+ */
+export type SafeCallResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: ApiCallError };
+
+/**
+ * API 调用错误类型
+ */
+export type ApiCallError = {
+  /** 错误类型 */
+  type: 'validation' | 'http' | 'network' | 'unknown';
+  /** 错误消息 */
+  message: string;
+  /** 原始错误对象 */
+  cause: unknown;
+  /** HTTP 状态码（仅 http 类型错误） */
+  statusCode?: number;
+  /** 验证错误详情（仅 validation 类型错误） */
+  validationError?: ApiValidationError;
+};
+
+/**
+ * 安全调用 API，返回 Result 类型而不是抛出异常
+ *
+ * 这个函数包装任何返回 Promise 的 API 调用，捕获所有可能的错误
+ * （包括验证错误、HTTP 错误、网络错误等），返回统一的 Result 类型。
+ *
+ * @param fn - 返回 Promise 的函数（通常是 API 调用）
+ * @returns SafeCallResult 类型，包含成功的数据或失败的错误信息
+ *
+ * @example
+ * ```typescript
+ * // 安全获取 PR 列表
+ * const result = await safeCall(() => client.pr.list(url));
+ *
+ * if (result.success) {
+ *   console.log('PR 数量:', result.data.length);
+ * } else {
+ *   switch (result.error.type) {
+ *     case 'validation':
+ *       console.error('API 响应格式错误:', result.error.message);
+ *       break;
+ *     case 'http':
+ *       console.error('HTTP 错误:', result.error.statusCode);
+ *       break;
+ *     case 'network':
+ *       console.error('网络错误:', result.error.message);
+ *       break;
+ *     default:
+ *       console.error('未知错误:', result.error.message);
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // 在轮询中使用，避免崩溃
+ * async function pollPRs() {
+ *   const result = await safeCall(() => client.pr.list(url));
+ *
+ *   if (!result.success) {
+ *     logger.warn('获取 PR 列表失败，将在下次轮询重试', result.error);
+ *     return; // 优雅处理，不崩溃
+ *   }
+ *
+ *   for (const pr of result.data) {
+ *     // 处理 PR...
+ *   }
+ * }
+ * ```
+ */
+export async function safeCall<T>(fn: () => Promise<T>): Promise<SafeCallResult<T>> {
+  try {
+    const data = await fn();
+    return { success: true, data };
+  } catch (error) {
+    return { success: false, error: classifyError(error) };
+  }
+}
+
+/**
+ * 对错误进行分类
+ */
+function classifyError(error: unknown): ApiCallError {
+  // 验证错误
+  if (error instanceof ApiValidationError) {
+    return {
+      type: 'validation',
+      message: error.getSummary(),
+      cause: error,
+      validationError: error,
+    };
+  }
+
+  // HTTP 错误
+  if (isHttpError(error)) {
+    const httpError = error as HttpError;
+    return {
+      type: 'http',
+      message: httpError.message || `HTTP ${httpError.response?.statusCode}`,
+      cause: error,
+      statusCode: httpError.response?.statusCode,
+    };
+  }
+
+  // 网络错误（ECONNREFUSED, ETIMEDOUT 等）
+  if (error instanceof Error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'ENETUNREACH'].includes(code)) {
+      return {
+        type: 'network',
+        message: `网络错误: ${code} - ${error.message}`,
+        cause: error,
+      };
+    }
+
+    // 其他 Error 类型
+    return {
+      type: 'unknown',
+      message: error.message,
+      cause: error,
+    };
+  }
+
+  // 未知错误
+  return {
+    type: 'unknown',
+    message: String(error),
+    cause: error,
+  };
+}
+
+/**
+ * 类型守卫：检查 SafeCallResult 是否成功
+ */
+export function isSuccess<T>(result: SafeCallResult<T>): result is { success: true; data: T } {
+  return result.success;
+}
+
+/**
+ * 类型守卫：检查 SafeCallResult 是否失败
+ */
+export function isFailure<T>(
+  result: SafeCallResult<T>,
+): result is { success: false; error: ApiCallError } {
+  return !result.success;
+}

--- a/packages/gitcode-api/src/index.ts
+++ b/packages/gitcode-api/src/index.ts
@@ -133,6 +133,9 @@ export type {
 export { ApiValidationError, type ApiValidationContext } from './client/errors.js';
 import { ApiValidationError } from './client/errors.js';
 
+// 安全解析 API 响应（不抛出异常）
+export { safeParseApiResponse, type ApiParseResult } from './client/parser.js';
+
 /**
  * 类型守卫：检查错误是否为 ApiValidationError
  *

--- a/packages/gitcode-api/src/index.ts
+++ b/packages/gitcode-api/src/index.ts
@@ -136,6 +136,15 @@ import { ApiValidationError } from './client/errors.js';
 // 安全解析 API 响应（不抛出异常）
 export { safeParseApiResponse, type ApiParseResult } from './client/parser.js';
 
+// 安全调用 API（不抛出异常）
+export {
+  safeCall,
+  isSuccess,
+  isFailure,
+  type SafeCallResult,
+  type ApiCallError,
+} from './client/safe-call.js';
+
 /**
  * 类型守卫：检查错误是否为 ApiValidationError
  *


### PR DESCRIPTION
- 新增 safeParseApiResponse 函数，返回 Result 类型而不是抛出异常
- 新增 ApiParseResult<T> 类型，表示解析成功或失败的结果
- 重构 parseApiResponse 函数，内部调用 safeParseApiResponse
- 添加完整的测试用例覆盖新功能
- 导出新函数和类型供外部使用

这个改进可以避免 Zod 验证失败时程序直接崩溃，允许调用方
优雅地处理验证错误。